### PR TITLE
Setup script: UX polish, MCP registration, hook registration

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -329,9 +329,11 @@ section "Registering MCP servers"
 
 _register_mcp() {
   local name="$1"
-  shift
-  # Check if already registered (claude mcp list includes all scopes)
-  if command -v claude &>/dev/null && claude mcp list 2>/dev/null | grep -q "^$name:"; then
+  local check_cmd="$2"
+  shift 2
+  # Check if already registered by looking for the command in mcp list output.
+  # We match on command (not name) since users may register under a different name.
+  if command -v claude &>/dev/null && claude mcp list 2>/dev/null | grep -q "$check_cmd"; then
     skip "$name already registered"
     return
   fi
@@ -344,11 +346,11 @@ _register_mcp() {
   if claude mcp add --scope user "$name" "$@" 2>/dev/null; then
     ok "$name"
   else
-    warn "$name — registration failed (run manually: claude mcp add $name $*)"
+    warn "$name — registration failed (run manually: claude mcp add --scope user $name $*)"
   fi
 }
 
-_register_mcp "playwright" -- npx @playwright/mcp@latest
+_register_mcp "playwright" "@playwright/mcp" -- npx @playwright/mcp@latest
 
 # --------------------------------------------------------------------------- #
 # 5. Upsert <agent-skills-guidance> block in CLAUDE.md                        #


### PR DESCRIPTION
## Summary

Completes the remaining items from #4 — polished terminal UX, MCP server registration, and hook registration in settings.json.

**What changed:**
- **UX overhaul**: Color-coded output with section headers, checkmarks, warnings, and dimmed skip messages. Prerequisites check up front. Quiet when idempotent — only highlights new changes.
- **MCP server registration**: Registers Playwright MCP server via `claude mcp add --scope user`. Idempotent — checks `claude mcp list` before adding.
- **Hook registration**: Ensures the PreToolUse hook entry exists in `settings.json` `hooks.PreToolUse` section. Previously setup.sh installed the hook files but didn't register the hook itself.

## Key Decisions

- MCP servers registered at `--scope user` (not project-local) so they're available across all repos
- MCP check uses `claude mcp list` output rather than parsing config files directly — more robust across config format changes
- Hook engine + rules still overwritten on every run (keeps them current), but hook registration is additive (won't duplicate)

## Test Plan

- [x] `uvx pytest hooks/PreToolUse/tests/` — 409 tests passing
- [x] Fresh run: all sections show ✓ for new installs
- [x] Second run: idempotent — shows "already registered" / "already linked" / "already present"
- [ ] Run from main repo (non-worktree) after merge

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)