### PR TITLE
deploy-aws skill + sync-guidance + template improvements

### DIFF
--- a/.claude/rules/python-packaging.md
+++ b/.claude/rules/python-packaging.md
@@ -1,0 +1,49 @@
+---
+paths: ["**/pyproject.toml", "**/uv.lock"]
+---
+
+## Python Packaging with uv
+
+### pyproject.toml structure
+
+Always use this structure for new Python projects/skills:
+
+```toml
+[project]
+name = "my-skill"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "some-package~=1.2",
+]
+
+[dependency-groups]
+dev = [
+    "pytest~=8.0",
+]
+```
+
+**Never use `[tool.uv]` with `dev-dependencies`** — that field is deprecated and produces a warning on every `uv run`. Use `[dependency-groups]` instead.
+
+### Dependency version ranges
+
+All dependencies must have bounded version ranges — bare `>=` is blocked by the hook engine.
+
+| Pattern | Use case |
+|---|---|
+| `~=1.2` | Allow patch + minor updates within major (preferred for most deps) |
+| `~=1.2.3` | Pin to patch updates only (for unstable APIs) |
+| `>=1.2,<2` | Explicit upper bound (equivalent to `~=1.2` but more verbose) |
+
+**Never write:** `"boto3>=1.35"`, `"fastapi>=0.115"` — always add the upper bound.
+
+### boto3 / botocore and AWS CLI auth
+
+When using boto3 with AWS CLI SSO/IAM Identity Center auth (`aws login`), add `botocore[crt]` as a dependency — it provides the credential provider required for token-based auth. Without it, boto3 sessions silently fail to resolve credentials.
+
+```toml
+dependencies = [
+    "boto3~=1.42",
+    "botocore[crt]~=1.42",
+]
+```

--- a/.claude/rules/rule-authoring.md
+++ b/.claude/rules/rule-authoring.md
@@ -1,0 +1,31 @@
+---
+paths: [".claude/rules/**"]
+---
+
+## Writing Rules: Scope Before You Save
+
+When creating a new rule in `.claude/rules/`, always ask: **does this only matter when working on specific file types or directories?**
+
+If yes, add a `paths` frontmatter to scope it — this keeps the always-loaded context lean and avoids injecting irrelevant rules into unrelated work.
+
+```markdown
+---
+paths: ["**/pyproject.toml", "**/*.toml"]
+---
+```
+
+**Scope it when the rule applies to:**
+- A specific file type (`.toml`, `Makefile`, `*.tsx`, `*.py`, etc.)
+- A specific directory or subtree (`apps/api/**`, `hooks/**`, `skills/*/SKILL.md`)
+- A specific tool or framework only used in certain files
+
+**Leave it unscoped (always loaded) when:**
+- It governs general behavior across all work (e.g., scope philosophy, verification policy)
+- You can't reliably predict which file types will trigger it
+- It's a process rule, not a code pattern rule (e.g., "never merge unless asked")
+
+**Examples from this repo:**
+- `makefile-style.md` → scoped to `**/Makefile`
+- `python-packaging.md` → scoped to `**/pyproject.toml`
+- `zero-tolerance-lint.md` → unscoped (applies to all template work regardless of file)
+- `scope-philosophy.md` → unscoped (governs behavior, not file content)

--- a/.claude/rules/skill-authoring.md
+++ b/.claude/rules/skill-authoring.md
@@ -3,3 +3,13 @@
 - Do not set `disable-model-invocation: true` in SKILL.md frontmatter unless the user explicitly asks for it. It blocks the skill from being invoked via the Skill tool, which breaks orchestration (e.g., solve-take-home calling /create-repo). If you see it on an existing skill, ask before keeping it — the answer will almost always be to remove it.
 - **Use context scripts for pre-loaded data.** When a skill needs data available at load time (before AI runs), use the `!` backtick pattern with a context script: `!~/.claude/skills/<skill>/scripts/context.sh <flag>`. Never use `cd && ...` compound commands in `!` backticks — they get blocked by permission checks. Wrap the logic in a context script instead.
 - **Deterministic work should be scripts, not AI.** If a step has no judgment calls (file I/O, shell commands, version lookups), make it a Python or shell script. The AI should only handle interview questions, diagnostics, and customizations.
+- **`AskUserQuestion` hard constraints (from schema):**
+  - `questions`: 1–4 per call (minItems: 1, maxItems: 4)
+  - `options`: exactly 2–4 per question (minItems: 2, maxItems: 4) — the tool auto-appends an "Other / type something different" entry; never add your own
+  - `header`: max 12 characters
+  - `label`: 1–5 words; `description`: explains the choice
+  - `multiSelect`: boolean, default false
+  - `preview`: only supported on single-select questions; renders a monospace markdown box for side-by-side comparison (good for code/layout mockups)
+  - Put the recommended/default option **first** — the UI selects it by default. Add `"(Recommended)"` to the label when you want to be explicit.
+  - **Never construct options from dynamic data without a ≥2 count guard.** If a data source (Dockerfiles found, derived names) yields only 1 item, either skip the question entirely or pad to 2 with a sensible alternative.
+  - **No iterative loops inside a batch.** All questions in one call are presented simultaneously and answers come back together. If question B's options depend on question A's answer, they must be separate `AskUserQuestion` calls — sequential, not batched.

--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,6 @@ dist/
 .work/
 .superset/
 install-deps.sh
+.claude/scheduled_tasks.lock
 
 .turbo/

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ init: ## Install deps, link skills & hooks, sync envs
 	@printf "\033[36mSyncing Python deps...\033[0m\n"
 	@cd skills/create-repo && uv sync --group dev --quiet
 	@cd skills/deploy-aws && uv sync --quiet
+	@printf "\033[36mInstalling Playwright browsers...\033[0m\n"
+	@cd skills/deploy-aws && uv run playwright install chromium --quiet 2>/dev/null || true
 	@printf "\033[36mRunning setup...\033[0m\n"
 	@./setup.sh
 	@main_repo=$$(git rev-parse --git-common-dir | sed 's|/\.git$$||'); \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: init test test-hooks test-create-repo test-scaffolds scaffold lint format format-check check help
+.PHONY: init test test-hooks test-create-repo test-scaffolds scaffold list-repo-templates lint format format-check check help
 
 ## Setup & daily use
 help: ## Show available commands
@@ -12,6 +12,7 @@ init: ## Install deps, link skills & hooks, sync envs
 	@command -v uv >/dev/null 2>&1 || { echo "Installing uv..."; curl -LsSf https://astral.sh/uv/install.sh | sh; }
 	@printf "\033[36mSyncing Python deps...\033[0m\n"
 	@cd skills/create-repo && uv sync --group dev --quiet
+	@cd skills/deploy-aws && uv sync --quiet
 	@printf "\033[36mRunning setup...\033[0m\n"
 	@./setup.sh
 	@main_repo=$$(git rev-parse --git-common-dir | sed 's|/\.git$$||'); \
@@ -39,10 +40,13 @@ test-scaffolds: ## Scaffold E2E (needs pnpm, node, Docker) [TEMPLATE=name|all] [
 	@printf "\033[36mRunning scaffold E2E...\033[0m\n"
 	@cd skills/create-repo && uv run python ../../scripts/test-scaffolds.py $(TEMPLATE) $(if $(KEEP),--keep $(KEEP))
 
-scaffold: ## Scaffold + setup a project without the AI interview [TEMPLATE=swift-ts NAME=my-app OUTPUT=~/Repos/my-app]
-	@[ -n "$(TEMPLATE)" ] || { echo "Usage: make scaffold TEMPLATE=swift-ts NAME=my-app OUTPUT=~/Repos/my-app"; exit 1; }
-	@[ -n "$(NAME)" ] || { echo "Usage: make scaffold TEMPLATE=swift-ts NAME=my-app OUTPUT=~/Repos/my-app"; exit 1; }
-	@[ -n "$(OUTPUT)" ] || { echo "Usage: make scaffold TEMPLATE=swift-ts NAME=my-app OUTPUT=~/Repos/my-app"; exit 1; }
+list-repo-templates: ## List available create-repo templates with descriptions
+	@cd skills/create-repo && uv run python -m scripts.list_templates --human
+
+scaffold: ## Scaffold + setup a project without the AI interview [TEMPLATE=swift-ts NAME=my-app OUTPUT=~/Repos/my-app] [GITHUB_ORG=ambroselittle]
+	@[ -n "$(TEMPLATE)" ] || { echo "Usage: make scaffold TEMPLATE=swift-ts NAME=my-app OUTPUT=~/Repos/my-app [GITHUB_ORG=ambroselittle]"; exit 1; }
+	@[ -n "$(NAME)" ] || { echo "Usage: make scaffold TEMPLATE=swift-ts NAME=my-app OUTPUT=~/Repos/my-app [GITHUB_ORG=ambroselittle]"; exit 1; }
+	@[ -n "$(OUTPUT)" ] || { echo "Usage: make scaffold TEMPLATE=swift-ts NAME=my-app OUTPUT=~/Repos/my-app [GITHUB_ORG=ambroselittle]"; exit 1; }
 	@printf "\033[36mResolving versions...\033[0m\n"
 	@cd skills/create-repo && uv run python -m scripts.resolve_versions --template $(TEMPLATE) --output /tmp/create-repo-versions.json
 	@printf "\033[36mScaffolding $(NAME)...\033[0m\n"
@@ -54,6 +58,12 @@ scaffold: ## Scaffold + setup a project without the AI interview [TEMPLATE=swift
 		$(if $(FORCE),--force,)
 	@printf "\033[36mSetting up...\033[0m\n"
 	cd skills/create-repo && uv run python -m scripts.scaffold --setup $(OUTPUT) $(if $(SKIP_DOCKER),--skip-docker,)
+	@printf "\033[36mInitializing git...\033[0m\n"
+	cd skills/create-repo && uv run python -m scripts.init_git $(OUTPUT) \
+		--project-name $(NAME) \
+		--template $(TEMPLATE) \
+		--stack "$(TEMPLATE) scaffold" \
+		$(if $(GITHUB_ORG),--github-org $(GITHUB_ORG),--no-github)
 
 ## Code quality
 check: format lint ## Auto-fix formatting and lint

--- a/skills/create-repo/SKILL.md
+++ b/skills/create-repo/SKILL.md
@@ -31,6 +31,7 @@ This is a hard stop — do not proceed, do not attempt to install it yourself, d
 The repo home finder results are pre-loaded below. Use them for the Location question.
 
 - Repo home: !`~/.claude/skills/create-repo/scripts/context.sh repo-home`
+- Available templates: !`~/.claude/skills/create-repo/scripts/context.sh list-templates`
 
 If the result is empty or `{}`, fall back to `./<project-name>` and `~/Code/<project-name>` as location options.
 

--- a/skills/create-repo/eval/checks/check_structure.py
+++ b/skills/create-repo/eval/checks/check_structure.py
@@ -231,7 +231,9 @@ def _check_node_ts_common(project_dir: Path, checks: list[CheckResult]) -> None:
             CheckResult(
                 "biome noUnusedImports is error",
                 no_unused == "error",
-                None if no_unused == "error" else f"noUnusedImports is '{no_unused}', expected 'error'",
+                None
+                if no_unused == "error"
+                else f"noUnusedImports is '{no_unused}', expected 'error'",
             )
         )
 
@@ -657,7 +659,8 @@ def _check_swift_ts(project_dir: Path, checks: list[CheckResult]) -> None:
         CheckResult(
             "file: *.xcworkspace/contents.xcworkspacedata",
             has_workspace and workspace_data is not None and workspace_data.exists(),
-            None if (has_workspace and workspace_data and workspace_data.exists())
+            None
+            if (has_workspace and workspace_data and workspace_data.exists())
             else "Missing pre-created Xcode workspace at repo root",
         )
     )

--- a/skills/create-repo/eval/run_eval.py
+++ b/skills/create-repo/eval/run_eval.py
@@ -63,6 +63,8 @@ FALLBACK_VERSIONS = {
     "testing_library_react": "16.3.2",
     "testing_library_jest_dom": "6.9.1",
     "dotenv": "17.4.1",
+    "tsx": "4.21.0",
+    "tsup": "8.5.1",
     "pnpm": "10.33.0",
     # GraphQL stack
     "graphql": "16.13.2",

--- a/skills/create-repo/scripts/context.sh
+++ b/skills/create-repo/scripts/context.sh
@@ -7,6 +7,9 @@ case "$1" in
   repo-home)
     cd "$SKILL_DIR" && uv run python -m scripts.find_repo_home 2>/dev/null || echo '{}'
     ;;
+  list-templates)
+    cd "$SKILL_DIR" && uv run python -m scripts.list_templates 2>/dev/null || echo '(templates unavailable)'
+    ;;
   *)
     echo "unknown flag: $1" >&2; exit 1
     ;;

--- a/skills/create-repo/scripts/list_templates.py
+++ b/skills/create-repo/scripts/list_templates.py
@@ -1,0 +1,43 @@
+"""List available create-repo templates from their template.json files."""
+
+import json
+import sys
+from pathlib import Path
+
+TEMPLATES_DIR = Path(__file__).parent.parent / "templates"
+
+
+def load_templates() -> list[tuple[str, str]]:
+    templates = []
+    for template_json in sorted(TEMPLATES_DIR.glob("*/template.json")):
+        if template_json.parent.name.startswith("_"):
+            continue
+        with open(template_json) as f:
+            data = json.load(f)
+        name = template_json.parent.name
+        description = data.get("description", "(no description)")
+        templates.append((name, description))
+    return templates
+
+
+def main() -> None:
+    human = "--human" in sys.argv
+    templates = load_templates()
+
+    if not templates:
+        print("No templates found.", file=sys.stderr)
+        sys.exit(1)
+
+    if human:
+        print("\nAvailable templates:\n")
+        max_name = max(len(t[0]) for t in templates)
+        for name, desc in templates:
+            print(f"  \033[36m{name:<{max_name}}\033[0m  {desc}")
+        print()
+    else:
+        for name, desc in templates:
+            print(f"{name} — {desc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/create-repo/scripts/resolve_versions.py
+++ b/skills/create-repo/scripts/resolve_versions.py
@@ -59,6 +59,8 @@ PACKAGE_REGISTRY: dict[str, tuple[str, str]] = {
     "testing_library_jest_dom": ("@testing-library/jest-dom", "npm"),
     "jsdom": ("jsdom", "npm"),
     "dotenv": ("dotenv", "npm"),
+    "tsx": ("tsx", "npm"),
+    "tsup": ("tsup", "npm"),
     # GraphQL
     "graphql": ("graphql", "npm"),
     "graphql_yoga": ("graphql-yoga", "npm"),

--- a/skills/create-repo/scripts/resolve_versions.py
+++ b/skills/create-repo/scripts/resolve_versions.py
@@ -291,7 +291,8 @@ def resolve_versions(
                     return cached_versions
                 else:
                     print(
-                        f"Cache missing {len(missing)} key(s) ({', '.join(sorted(missing))}) — re-resolving fresh.",
+                        f"Cache missing {len(missing)} key(s)"
+                        f" ({', '.join(sorted(missing))}) — re-resolving fresh.",
                         file=sys.stderr,
                     )
                     # Fall through to full fresh resolution below

--- a/skills/create-repo/scripts/resolve_versions.py
+++ b/skills/create-repo/scripts/resolve_versions.py
@@ -276,12 +276,25 @@ def resolve_versions(
             cache = json.loads(cache_path.read_text())
             cached_at = cache.get("cached_at", 0)
             if time.time() - cached_at < 86400:  # 24 hours
-                print(
-                    f"Using cached versions from {cache.get('cached_at_human', 'unknown')}. "
-                    "Pass --fresh to re-resolve.",
-                    file=sys.stderr,
-                )
-                return cache["versions"]
+                cached_versions = cache["versions"]
+                # Validate cache covers everything the template actually needs.
+                # New version keys added to templates after the cache was written
+                # would cause a Jinja2 UndefinedError at render time — catch it here.
+                required_keys = discover_required_keys(template_name)
+                missing = required_keys - set(cached_versions.keys())
+                if not missing:
+                    print(
+                        f"Using cached versions from {cache.get('cached_at_human', 'unknown')}. "
+                        "Pass --fresh to re-resolve.",
+                        file=sys.stderr,
+                    )
+                    return cached_versions
+                else:
+                    print(
+                        f"Cache missing {len(missing)} key(s) ({', '.join(sorted(missing))}) — re-resolving fresh.",
+                        file=sys.stderr,
+                    )
+                    # Fall through to full fresh resolution below
         except (json.JSONDecodeError, KeyError):
             pass  # Corrupted cache, re-resolve
 

--- a/skills/create-repo/scripts/scaffold.py
+++ b/skills/create-repo/scripts/scaffold.py
@@ -379,8 +379,9 @@ def _run_setup_step(
         if proc.returncode != 0:
             parts = [s for s in (proc.stderr.strip(), proc.stdout.strip()) if s]
             error = "\n".join(parts) if parts else f"Exit code {proc.returncode}"
-            if len(error) > 2000:
-                error = error[:2000] + "\n... (truncated)"
+            from scripts.verify import truncate_error
+
+            error = truncate_error(error)
             return SetupStepResult(name=name, passed=False, duration_s=elapsed, error=error)
         return SetupStepResult(name=name, passed=True, duration_s=elapsed)
     except subprocess.TimeoutExpired:

--- a/skills/create-repo/scripts/verify.py
+++ b/skills/create-repo/scripts/verify.py
@@ -22,6 +22,19 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from urllib.request import urlopen
 
+MAX_ERROR_LEN = 4000
+
+
+def truncate_error(text: str, limit: int = MAX_ERROR_LEN) -> str:
+    """Truncate long error output, keeping head and tail so the actual error is visible."""
+    if len(text) <= limit:
+        return text
+    # Keep first 1/3 and last 2/3 — the useful error is usually at the end
+    head_len = limit // 3
+    tail_len = limit - head_len
+    marker = "\n\n... (truncated — showing first and last lines) ...\n\n"
+    return text[:head_len] + marker + text[-tail_len:]
+
 
 @dataclass
 class StepResult:
@@ -72,15 +85,13 @@ def run_step(
             # Combine stderr and stdout — tools like turbo put their own
             # error wrapper on stderr while the actual child error is on stdout.
             error = combined if combined else f"Exit code {proc.returncode}"
-            # Truncate long error output
-            if len(error) > 2000:
-                error = error[:2000] + "\n... (truncated)"
+            error = truncate_error(error)
             return StepResult(name=name, passed=False, duration_s=elapsed, error=error)
         if fail_on_output:
             for pattern in fail_on_output:
                 m = re.search(pattern, combined)
                 if m:
-                    snippet = combined[:2000] + ("\n... (truncated)" if len(combined) > 2000 else "")
+                    snippet = truncate_error(combined)
                     return StepResult(
                         name=name,
                         passed=False,
@@ -454,8 +465,7 @@ def verify_node(
                         if e2e_proc.returncode != 0:
                             e2e_log.seek(0)
                             error = e2e_log.read().strip()
-                            if len(error) > 2000:
-                                error = error[:2000] + "\n... (truncated)"
+                            error = truncate_error(error)
                             step = StepResult(e2e_name, False, e2e_elapsed, error)
                         else:
                             step = StepResult(e2e_name, True, e2e_elapsed)
@@ -734,9 +744,7 @@ def verify_fullstack_python(
                     e2e_elapsed = time.monotonic() - e2e_start
                     if e2e_proc.returncode != 0:
                         e2e_log.seek(0)
-                        error = e2e_log.read().strip()
-                        if len(error) > 2000:
-                            error = error[:2000] + "\n... (truncated)"
+                        error = truncate_error(e2e_log.read().strip())
                         step = StepResult("e2e tests (web)", False, e2e_elapsed, error)
                     else:
                         step = StepResult("e2e tests (web)", True, e2e_elapsed)

--- a/skills/create-repo/templates/__common/CLAUDE.md.j2
+++ b/skills/create-repo/templates/__common/CLAUDE.md.j2
@@ -23,6 +23,11 @@ This is a pnpm monorepo managed with Turborepo.
 2. `pnpm db:push` — Push database schema
 3. `pnpm start` — Start Postgres + dev servers
 
+## Docker
+
+- `docker compose up` — Start Postgres only (dev workflow)
+- `docker compose -f docker-compose.yml -f docker-compose.containers.yml up --build` — Start full container stack (API + web + Postgres), mirrors production
+
 ## Conventions
 
 - Strict TypeScript (`strict: true`)

--- a/skills/create-repo/templates/api-ts/apps/api/package.json.j2
+++ b/skills/create-repo/templates/api-ts/apps/api/package.json.j2
@@ -24,6 +24,7 @@
     "zod": "latest"
   },
   "devDependencies": {
+    "@types/node": "latest",
     "@playwright/test": "{{ versions.playwright_test }}",
     "tsx": "latest",
     "typescript": "{{ versions.typescript }}",

--- a/skills/create-repo/templates/api-ts/template.json
+++ b/skills/create-repo/templates/api-ts/template.json
@@ -1,5 +1,6 @@
 {
   "platform": "ts",
+  "description": "TypeScript API only (no frontend) — Hono + tRPC + Prisma + Postgres",
   "extends": "fullstack-ts",
   "exclude": [
     "apps/web/**"

--- a/skills/create-repo/templates/fullstack-graphql/apps/api/package.json.j2
+++ b/skills/create-repo/templates/fullstack-graphql/apps/api/package.json.j2
@@ -24,6 +24,7 @@
     "dotenv": "{{ versions.dotenv }}"
   },
   "devDependencies": {
+    "@types/node": "latest",
     "tsup": "{{ versions.tsup }}",
     "tsx": "{{ versions.tsx }}",
     "typescript": "{{ versions.typescript }}",

--- a/skills/create-repo/templates/fullstack-graphql/apps/api/package.json.j2
+++ b/skills/create-repo/templates/fullstack-graphql/apps/api/package.json.j2
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "bash scripts/dev.sh",
     "generate:schema": "tsx scripts/print-schema.ts",
-    "build": "tsc",
+    "build": "tsup",
     "start": "node dist/index.js",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
@@ -21,10 +21,11 @@
     "graphql": "{{ versions.graphql }}",
     "graphql-yoga": "{{ versions.graphql_yoga }}",
     "hono": "{{ versions.hono }}",
-    "dotenv": "latest"
+    "dotenv": "{{ versions.dotenv }}"
   },
   "devDependencies": {
-    "tsx": "latest",
+    "tsup": "{{ versions.tsup }}",
+    "tsx": "{{ versions.tsx }}",
     "typescript": "{{ versions.typescript }}",
     "vitest": "{{ versions.vitest }}"
   }

--- a/skills/create-repo/templates/fullstack-graphql/apps/api/tsup.config.ts
+++ b/skills/create-repo/templates/fullstack-graphql/apps/api/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsup"
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: false,
+  platform: "node",
+})

--- a/skills/create-repo/templates/fullstack-graphql/template.json
+++ b/skills/create-repo/templates/fullstack-graphql/template.json
@@ -1,5 +1,6 @@
 {
   "platform": "ts",
+  "description": "React + Hono + GraphQL (Yoga/Pothos) + Apollo Client + Prisma + Postgres + Tailwind/shadcn",
   "extends": "fullstack-ts",
   "exclude": [
     "apps/api/src/router.ts.j2",

--- a/skills/create-repo/templates/fullstack-python/template.json
+++ b/skills/create-repo/templates/fullstack-python/template.json
@@ -1,5 +1,6 @@
 {
   "platform": ["ts", "python"],
+  "description": "React + FastAPI + Postgres + Tailwind/shadcn",
   "extends": "fullstack-ts",
   "exclude": [
     "apps/api/**",

--- a/skills/create-repo/templates/fullstack-ts/.dockerignore
+++ b/skills/create-repo/templates/fullstack-ts/.dockerignore
@@ -1,0 +1,7 @@
+**/node_modules
+**/.env
+**/.env.*
+!**/.env.example
+**/dist
+.git
+.work

--- a/skills/create-repo/templates/fullstack-ts/apps/api/Dockerfile.j2
+++ b/skills/create-repo/templates/fullstack-ts/apps/api/Dockerfile.j2
@@ -30,6 +30,8 @@ COPY --from=builder /app/packages/db/package.json ./packages/db/package.json
 COPY --from=builder /app/packages/types/dist ./packages/types/dist
 COPY --from=builder /app/packages/types/package.json ./packages/types/package.json
 COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/apps/api/node_modules ./apps/api/node_modules
+COPY --from=builder /app/packages/db/node_modules ./packages/db/node_modules
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
 EXPOSE 3001

--- a/skills/create-repo/templates/fullstack-ts/apps/api/Dockerfile.j2
+++ b/skills/create-repo/templates/fullstack-ts/apps/api/Dockerfile.j2
@@ -1,0 +1,36 @@
+FROM node:22-alpine AS base
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+# Prune monorepo to only what the API needs
+FROM base AS pruner
+WORKDIR /app
+RUN pnpm add -g turbo
+COPY . .
+RUN turbo prune @{{ scope }}/api --docker
+
+# Build — single stage so pnpm workspace links are consistent
+FROM base AS builder
+WORKDIR /app
+COPY --from=pruner /app/out/json/ .
+COPY --from=pruner /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
+RUN pnpm install --frozen-lockfile
+COPY --from=pruner /app/out/full/ .
+RUN pnpm turbo build --filter=@{{ scope }}/api
+
+# Runtime — lean image with only built output
+FROM node:22-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/apps/api/dist ./apps/api/dist
+COPY --from=builder /app/apps/api/package.json ./apps/api/package.json
+COPY --from=builder /app/packages/db/dist ./packages/db/dist
+COPY --from=builder /app/packages/db/package.json ./packages/db/package.json
+COPY --from=builder /app/packages/types/dist ./packages/types/dist
+COPY --from=builder /app/packages/types/package.json ./packages/types/package.json
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
+EXPOSE 3001
+CMD ["node", "apps/api/dist/index.js"]

--- a/skills/create-repo/templates/fullstack-ts/apps/api/package.json.j2
+++ b/skills/create-repo/templates/fullstack-ts/apps/api/package.json.j2
@@ -23,6 +23,7 @@
     "zod": "latest"
   },
   "devDependencies": {
+    "@types/node": "latest",
     "tsup": "{{ versions.tsup }}",
     "tsx": "{{ versions.tsx }}",
     "typescript": "{{ versions.typescript }}",

--- a/skills/create-repo/templates/fullstack-ts/apps/api/package.json.j2
+++ b/skills/create-repo/templates/fullstack-ts/apps/api/package.json.j2
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "dev": "bash scripts/dev.sh",
-    "build": "tsc",
+    "build": "tsup",
     "start": "node dist/index.js",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
@@ -19,11 +19,12 @@
     "@hono/trpc-server": "{{ versions.hono_trpc_server }}",
     "@trpc/server": "{{ versions.trpc_server }}",
     "hono": "{{ versions.hono }}",
-    "dotenv": "latest",
+    "dotenv": "{{ versions.dotenv }}",
     "zod": "latest"
   },
   "devDependencies": {
-    "tsx": "latest",
+    "tsup": "{{ versions.tsup }}",
+    "tsx": "{{ versions.tsx }}",
     "typescript": "{{ versions.typescript }}",
     "vitest": "{{ versions.vitest }}"
   }

--- a/skills/create-repo/templates/fullstack-ts/apps/api/tsup.config.ts
+++ b/skills/create-repo/templates/fullstack-ts/apps/api/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsup"
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: false,
+  platform: "node",
+})

--- a/skills/create-repo/templates/fullstack-ts/apps/web/Dockerfile.j2
+++ b/skills/create-repo/templates/fullstack-ts/apps/web/Dockerfile.j2
@@ -1,0 +1,28 @@
+FROM node:22-alpine AS base
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+# Prune monorepo to only what the web app needs
+FROM base AS pruner
+WORKDIR /app
+RUN pnpm add -g turbo
+COPY . .
+RUN turbo prune @{{ scope }}/web --docker
+
+# Build static assets — single stage so pnpm workspace links are consistent
+FROM base AS builder
+WORKDIR /app
+COPY --from=pruner /app/out/json/ .
+COPY --from=pruner /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
+RUN pnpm install --frozen-lockfile
+COPY --from=pruner /app/out/full/ .
+RUN pnpm turbo build --filter=@{{ scope }}/web
+
+# Serve via nginx — proxies /api to API_HOST at runtime
+FROM nginx:alpine AS runner
+COPY --from=builder /app/apps/web/dist /usr/share/nginx/html
+COPY --from=builder /app/apps/web/nginx.conf /etc/nginx/templates/default.conf.template
+ENV API_HOST=http://api:3001
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/skills/create-repo/templates/fullstack-ts/apps/web/nginx.conf
+++ b/skills/create-repo/templates/fullstack-ts/apps/web/nginx.conf
@@ -3,11 +3,18 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Proxy API requests to the API service
+    # Required for runtime DNS resolution when proxy_pass uses a variable
+    resolver 8.8.8.8 8.8.4.4 valid=30s ipv6=off;
+
+    # Proxy API requests to the API service.
+    # Using a variable for proxy_pass enables runtime DNS resolution and
+    # allows proxy_ssl_server_name to work correctly for HTTPS upstreams.
     location /api/ {
-        proxy_pass ${API_HOST};
+        set $api_upstream ${API_HOST};
+        proxy_pass $api_upstream;
+        proxy_ssl_server_name on;
         proxy_http_version 1.1;
-        proxy_set_header Host $host;
+        proxy_set_header Host $proxy_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;

--- a/skills/create-repo/templates/fullstack-ts/apps/web/nginx.conf
+++ b/skills/create-repo/templates/fullstack-ts/apps/web/nginx.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Proxy API requests to the API service
+    location /api/ {
+        proxy_pass ${API_HOST};
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # SPA fallback — all other routes serve index.html
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/skills/create-repo/templates/fullstack-ts/docker-compose.containers.yml.j2
+++ b/skills/create-repo/templates/fullstack-ts/docker-compose.containers.yml.j2
@@ -1,0 +1,36 @@
+# Container stack override — runs API and web in Docker alongside the database.
+# Use this to verify containerized behavior locally before deploying.
+#
+#   docker compose -f docker-compose.yml -f docker-compose.containers.yml up --build
+#
+# Web: http://localhost:3000
+# API: http://localhost:3001
+# GraphQL: http://localhost:3001/api/graphql (fullstack-graphql only)
+
+services:
+  api:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+    ports:
+      - "${API_PORT:-3001}:3001"
+    environment:
+      PORT: "3001"
+      NODE_ENV: production
+      DATABASE_URL: "postgresql://postgres:postgres@postgres:5432/{{ project_name }}_dev?sslmode=disable"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+
+  web:
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
+    ports:
+      - "${WEB_PORT:-3000}:80"
+    environment:
+      API_HOST: "http://api:3001"
+    depends_on:
+      - api
+    restart: unless-stopped

--- a/skills/create-repo/templates/fullstack-ts/packages/db/package.json.j2
+++ b/skills/create-repo/templates/fullstack-ts/packages/db/package.json.j2
@@ -3,11 +3,12 @@
   "private": true,
   "type": "module",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "generate": "prisma generate && tsx scripts/generate-barrel.ts",
     "db:push": "prisma db push",
     "db:seed": "tsx prisma/seed.ts",
-    "build": "tsup",
+    "build": "tsup && tsc --emitDeclarationOnly",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/skills/create-repo/templates/fullstack-ts/packages/db/package.json.j2
+++ b/skills/create-repo/templates/fullstack-ts/packages/db/package.json.j2
@@ -2,22 +2,23 @@
   "name": "{{ scope }}/db",
   "private": true,
   "type": "module",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
   "scripts": {
     "generate": "prisma generate && tsx scripts/generate-barrel.ts",
     "db:push": "prisma db push",
     "db:seed": "tsx prisma/seed.ts",
-    "build": "tsc",
+    "build": "tsup",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@prisma/client": "{{ versions.prisma_client }}",
     "@prisma/adapter-pg": "{{ versions.prisma_adapter_pg }}",
-    "dotenv": "latest"
+    "dotenv": "{{ versions.dotenv }}"
   },
   "devDependencies": {
     "prisma": "{{ versions.prisma }}",
-    "tsx": "latest",
+    "tsup": "{{ versions.tsup }}",
+    "tsx": "{{ versions.tsx }}",
     "typescript": "{{ versions.typescript }}"
   }
 }

--- a/skills/create-repo/templates/fullstack-ts/packages/db/src/index.ts
+++ b/skills/create-repo/templates/fullstack-ts/packages/db/src/index.ts
@@ -2,7 +2,12 @@ import "dotenv/config"
 import { PrismaPg } from "@prisma/adapter-pg"
 import { PrismaClient } from "./generated/prisma/client"
 
-const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL })
+// In production, RDS requires SSL but the pg adapter doesn't enable it by default.
+// Passing ssl: { rejectUnauthorized: false } handles cases where the DATABASE_URL
+// doesn't include sslmode params (e.g. local dev). No-op when SSL is not required.
+const sslOptions =
+  process.env.NODE_ENV === "production" ? { ssl: { rejectUnauthorized: false } } : {}
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL, ...sslOptions })
 export const db = new PrismaClient({ adapter })
 
 export type { PrismaClient } from "./generated/prisma/client"

--- a/skills/create-repo/templates/fullstack-ts/packages/db/tsup.config.ts
+++ b/skills/create-repo/templates/fullstack-ts/packages/db/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup"
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: false,
+  platform: "node",
+  // Keep Prisma and pg as external — they must be loaded from node_modules at runtime
+  external: ["@prisma/client", "@prisma/adapter-pg", "pg"],
+})

--- a/skills/create-repo/templates/fullstack-ts/template.json
+++ b/skills/create-repo/templates/fullstack-ts/template.json
@@ -1,3 +1,4 @@
 {
-  "platform": "ts"
+  "platform": "ts",
+  "description": "React + Hono + tRPC + Prisma + Postgres + Tailwind/shadcn"
 }

--- a/skills/create-repo/templates/swift-ts/apps/api/package.json.j2
+++ b/skills/create-repo/templates/swift-ts/apps/api/package.json.j2
@@ -24,6 +24,7 @@
     "zod": "latest"
   },
   "devDependencies": {
+    "@types/node": "latest",
     "@playwright/test": "{{ versions.playwright_test }}",
     "tsx": "latest",
     "typescript": "{{ versions.typescript }}",

--- a/skills/create-repo/templates/swift-ts/template.json
+++ b/skills/create-repo/templates/swift-ts/template.json
@@ -1,5 +1,6 @@
 {
   "platform": "ts",
+  "description": "Swift multiplatform (iOS/iPadOS/Mac/visionOS) + Hono REST API + Prisma + Postgres",
   "extends": "fullstack-ts",
   "exclude": [
     "apps/web/**",

--- a/skills/create-repo/tests/test_init_git.py
+++ b/skills/create-repo/tests/test_init_git.py
@@ -25,7 +25,9 @@ def test_run_cmd_success():
 
 
 def test_run_cmd_failure_raises():
-    with patch("scripts.init_git.subprocess.run", return_value=_mock_run(returncode=1, stderr="bad")):
+    with patch(
+        "scripts.init_git.subprocess.run", return_value=_mock_run(returncode=1, stderr="bad")
+    ):
         with pytest.raises(subprocess.CalledProcessError):
             run_cmd(["git", "bad-command"], Path("/tmp"))
 

--- a/skills/create-repo/tests/test_scaffold.py
+++ b/skills/create-repo/tests/test_scaffold.py
@@ -49,6 +49,8 @@ def versions() -> dict:
         "testing_library_react": "16.3.2",
         "testing_library_jest_dom": "6.9.1",
         "dotenv": "17.4.1",
+        "tsx": "4.21.0",
+        "tsup": "8.5.1",
         "pnpm": "10.33.0",
         # GraphQL stack
         "graphql": "16.13.2",

--- a/skills/create-repo/tests/test_verify.py
+++ b/skills/create-repo/tests/test_verify.py
@@ -44,12 +44,13 @@ def test_run_step_timeout():
 
 
 def test_run_step_truncates_long_errors():
-    long_error = "x" * 3000
+    long_error = "x" * 6000
     with patch(
         "scripts.verify.subprocess.run", return_value=_mock_run(returncode=1, stderr=long_error)
     ):
         result = run_step("failing", ["cmd"], Path("/tmp"))
-    assert len(result.error) < 2100  # 2000 + truncation message
+    assert len(result.error) < 4200  # MAX_ERROR_LEN + marker text
+    assert "truncated" in result.error
 
 
 # --- VerifyResult ---

--- a/skills/deploy-aws/SKILL.md
+++ b/skills/deploy-aws/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: deploy-aws
+description: Deploy a project to AWS using App Runner (containers) + RDS (Postgres). Detects Dockerfiles, provisions infra, builds and pushes images, deploys services, and prints live URLs. Optimized for agent-skills templates but works on any repo with Dockerfiles.
+argument-hint: "[update]"
+---
+
+# Deploy to AWS
+
+You are a deployment assistant. Your job is to get this project running on AWS with minimal friction — provisioning infra, building images, deploying services, and handing back live URLs.
+
+**Arguments:** $ARGUMENTS
+- `update` — skip interview, re-deploy using existing `.deploy-aws.json` config
+
+**Pre-loaded context:**
+
+- AWS auth: !`~/.claude/skills/deploy-aws/scripts/context.sh auth-status`
+- Dockerfiles found: !`~/.claude/skills/deploy-aws/scripts/context.sh dockerfiles`
+- Existing deploy config: !`~/.claude/skills/deploy-aws/scripts/context.sh deploy-config`
+- Repo template type: !`~/.claude/skills/deploy-aws/scripts/context.sh template-type`
+
+---
+
+## Step 0: Auth Check
+
+If the AWS auth pre-loaded context shows an error or is empty:
+
+> "AWS CLI isn't authenticated. Run `aws login` in your terminal (it opens a browser), then retry."
+
+Stop here until auth is confirmed.
+
+---
+
+## Step 1: Assess State
+
+If `$ARGUMENTS` includes `update` **and** `.deploy-aws.json` exists with a valid config:
+- Skip the interview entirely
+- Jump to Step 3 (build + push)
+
+If `.deploy-aws.json` exists but `update` was not passed:
+- Tell the user: "Found existing deploy config for `<app>` in `<region>`. This will update the running services. Proceed?"
+- If yes: skip interview, jump to Step 3
+- If no: proceed with interview (may overwrite config)
+
+---
+
+## Step 2: Interview
+
+Use `AskUserQuestion` for every question. Batch independent questions in one call (max 4 per call).
+
+**AskUserQuestion constraints:**
+- `questions`: array of 1–4 question objects
+- Each: `question` (string), `header` (max 12 chars), `options` (2–4 items), `multiSelect` (boolean)
+- Each option: `label` (1–5 words), `description`
+- Tool auto-adds "Other" for free text — don't add it yourself
+- Put the most common/default first
+
+### Batch 1 — App basics
+
+Ask these together:
+
+**Question 1 — App name:**
+- header: `"App Name"`
+- question: `"What should this deployment be called? (used for ECR repos, App Runner service names, and RDS identifier)"`
+- options (always provide exactly 2):
+  - label: derived from repo directory name (e.g. `"test-graphql"`), description: `"Derived from repo name — recommended"`
+  - label: derived name + `-app` suffix (e.g. `"test-graphql-app"`), description: `"Alternate slug if the base name is taken in AWS"`
+
+**Question 2 — AWS region:**
+- header: `"Region"`
+- question: `"Which AWS region?"`
+- options:
+  - `"us-east-1"` — US East (N. Virginia) — lowest latency to most US users, most services available
+  - `"us-west-2"` — US West (Oregon) — good US West Coast latency
+  - `"eu-west-1"` — EU (Ireland) — EU users
+
+### Batch 2 — Services (only if 3+ Dockerfiles found)
+
+**Default: deploy all services found.** Do not ask unless there are 3 or more Dockerfiles — at that point it's worth confirming the user doesn't want to skip any.
+
+If 1–2 Dockerfiles found: skip this question, deploy all of them automatically.
+
+If 3+ Dockerfiles found, ask one opt-out question:
+
+**Question — Skip any services?:**
+- header: `"Skip Any?"`
+- question: `"Found N services (list them). Deploy all of them?"`
+- options:
+  - `"Deploy all"` — deploy everything found (default)
+  - `"Skip some"` — I'll tell you which ones to leave out
+- If they choose "Skip some": follow up asking which to exclude (free text or another question)
+
+### Batch 3 — Database
+
+**Question — Database:**
+- header: `"Database"`
+- question: `"Does this app need a Postgres database on RDS?"`
+- options:
+  - `"Yes, create RDS"` — Provision a free-tier RDS Postgres instance (db.t3.micro)
+  - `"No database"` — Skip RDS (app uses an external DB or none)
+  - `"Use existing"` — I'll provide a DATABASE_URL
+
+If "Use existing": ask for the DATABASE_URL as free text.
+
+### Confirm
+
+Summarize the plan:
+- App name, region
+- Services to deploy (with Dockerfile paths)
+- Database choice
+- Estimated AWS costs (App Runner: ~$0–5/mo on free tier; RDS free tier: $0 for 12 months)
+
+Ask: "Ready to deploy?" before proceeding.
+
+---
+
+## Step 3: Provision Infrastructure
+
+Run the provision script. This is idempotent — safe to re-run.
+
+```bash
+uv run --project ~/.claude/skills/deploy-aws python ~/.claude/skills/deploy-aws/scripts/provision.py \
+  --app <app-name> \
+  --region <region> \
+  --services <comma-separated service names, e.g. "api,web"> \
+  --db <"rds"|"external:<DATABASE_URL>"|"none">
+```
+
+This creates:
+- ECR repository for each service
+- IAM role for App Runner to pull from ECR
+- RDS Postgres instance + security group (if `--db rds`)
+
+It saves state to `.deploy-aws.json` in the current directory and prints a summary.
+
+If it fails: read the error, diagnose (common issues: region not enabled, service limits, insufficient permissions), fix or guide the user, then retry once.
+
+---
+
+## Step 4: Build and Push Images
+
+For each service being deployed, build its Docker image and push to ECR.
+
+```bash
+uv run --project ~/.claude/skills/deploy-aws python ~/.claude/skills/deploy-aws/scripts/build-push.py \
+  --service <service-name>
+```
+
+Run these **sequentially** — Docker builds are CPU/memory intensive. Show progress as each service builds.
+
+If a build fails: show the last 20 lines of output, diagnose the error (missing files, wrong context path, etc.), and ask the user how to proceed.
+
+---
+
+## Step 5: Deploy Services
+
+Deploy each service to App Runner. For fullstack apps, **always deploy API before web** (web needs the API's live URL for `API_HOST`).
+
+```bash
+uv run --project ~/.claude/skills/deploy-aws python ~/.claude/skills/deploy-aws/scripts/deploy.py \
+  --service <service-name>
+```
+
+The script waits for the service to reach RUNNING state (polls every 10s, times out at 5 min).
+
+If deploying web after api: the script automatically reads the API's live URL from `.deploy-aws.json` and sets `API_HOST` accordingly.
+
+---
+
+## Step 6: Done
+
+Print a clean summary:
+
+```
+Deployed successfully!
+
+Services:
+  api  → https://<id>.us-east-1.awsapprunner.com
+  web  → https://<id>.us-east-1.awsapprunner.com
+
+Database: <endpoint>:5432/<db-name>  (RDS free tier — remember to delete when done)
+
+Config saved to .deploy-aws.json — run /deploy-aws update to redeploy.
+```
+
+If any service URL is for the web app, open it: `open <url>`.
+
+---
+
+## Guidelines
+
+- **Always provision before build** — ECR repos must exist before pushing images.
+- **API before web** — web's `API_HOST` env var needs the API's live URL.
+- **Idempotency** — all scripts are safe to re-run. Re-running provision won't duplicate resources.
+- **Free tier** — remind the user to delete RDS when done if they don't need it long-term (`aws rds delete-db-instance --db-instance-identifier <id> --skip-final-snapshot`).
+- **Secrets** — never log or print DATABASE_URL or passwords to the terminal. The scripts handle this.

--- a/skills/deploy-aws/SKILL.md
+++ b/skills/deploy-aws/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deploy-aws
 description: Deploy a project to AWS using App Runner (containers) + RDS (Postgres). Detects Dockerfiles, provisions infra, builds and pushes images, deploys services, and prints live URLs. Optimized for agent-skills templates but works on any repo with Dockerfiles.
-argument-hint: "[update]"
+argument-hint: "[update|cleanup]"
 ---
 
 # Deploy to AWS
@@ -10,6 +10,7 @@ You are a deployment assistant. Your job is to get this project running on AWS w
 
 **Arguments:** $ARGUMENTS
 - `update` — skip interview, re-deploy using existing `.deploy-aws.json` config
+- `cleanup` — tear down all provisioned AWS resources and delete `.deploy-aws.json`
 
 **Pre-loaded context:**
 
@@ -20,7 +21,21 @@ You are a deployment assistant. Your job is to get this project running on AWS w
 
 ---
 
-## Step 0: Auth Check
+## Step 0: Cleanup (early exit)
+
+If `$ARGUMENTS` is `cleanup`:
+
+1. Confirm with the user: "This will delete all AWS resources for the app in `.deploy-aws.json` (App Runner services, ECR repos, RDS instance, security group, IAM role). This cannot be undone. Proceed?"
+2. If confirmed, run:
+   ```bash
+   uv run --project ~/.claude/skills/deploy-aws python ~/.claude/skills/deploy-aws/scripts/cleanup.py
+   ```
+   Pass `--keep-config` if the user says they want to keep `.deploy-aws.json`.
+3. Print the script output and stop — do not proceed to any other steps.
+
+---
+
+## Step 1: Auth Check
 
 If the AWS auth pre-loaded context shows an error or is empty:
 
@@ -30,20 +45,20 @@ Stop here until auth is confirmed.
 
 ---
 
-## Step 1: Assess State
+## Step 2: Assess State
 
 If `$ARGUMENTS` includes `update` **and** `.deploy-aws.json` exists with a valid config:
 - Skip the interview entirely
-- Jump to Step 3 (build + push)
+- Jump to Step 4 (build + push)
 
 If `.deploy-aws.json` exists but `update` was not passed:
 - Tell the user: "Found existing deploy config for `<app>` in `<region>`. This will update the running services. Proceed?"
-- If yes: skip interview, jump to Step 3
+- If yes: skip interview, jump to Step 4
 - If no: proceed with interview (may overwrite config)
 
 ---
 
-## Step 2: Interview
+## Step 3: Interview
 
 Use `AskUserQuestion` for every question. Batch independent questions in one call (max 4 per call).
 
@@ -113,7 +128,7 @@ Ask: "Ready to deploy?" before proceeding.
 
 ---
 
-## Step 3: Provision Infrastructure
+## Step 4: Provision Infrastructure
 
 Run the provision script. This is idempotent — safe to re-run.
 
@@ -136,7 +151,7 @@ If it fails: read the error, diagnose (common issues: region not enabled, servic
 
 ---
 
-## Step 4: Build and Push Images
+## Step 5: Build and Push Images
 
 For each service being deployed, build its Docker image and push to ECR.
 
@@ -151,7 +166,7 @@ If a build fails: show the last 20 lines of output, diagnose the error (missing 
 
 ---
 
-## Step 5: Deploy Services
+## Step 6: Deploy Services
 
 Deploy each service to App Runner. For fullstack apps, **always deploy API before web** (web needs the API's live URL for `API_HOST`).
 
@@ -166,7 +181,7 @@ If deploying web after api: the script automatically reads the API's live URL fr
 
 ---
 
-## Step 6: Done
+## Step 7: Done
 
 Print a clean summary:
 
@@ -191,5 +206,5 @@ If any service URL is for the web app, open it: `open <url>`.
 - **Always provision before build** — ECR repos must exist before pushing images.
 - **API before web** — web's `API_HOST` env var needs the API's live URL.
 - **Idempotency** — all scripts are safe to re-run. Re-running provision won't duplicate resources.
-- **Free tier** — remind the user to delete RDS when done if they don't need it long-term (`aws rds delete-db-instance --db-instance-identifier <id> --skip-final-snapshot`).
+- **Free tier** — remind the user to tear everything down when done if they don't need it long-term. Say: "Run `/deploy-aws cleanup` to remove all provisioned resources."
 - **Secrets** — never log or print DATABASE_URL or passwords to the terminal. The scripts handle this.

--- a/skills/deploy-aws/pyproject.toml
+++ b/skills/deploy-aws/pyproject.toml
@@ -5,6 +5,7 @@ requires-python = ">=3.12"
 dependencies = [
     "boto3~=1.42",
     "botocore[crt]~=1.42",
+    "playwright~=1.49",
 ]
 
 [dependency-groups]

--- a/skills/deploy-aws/pyproject.toml
+++ b/skills/deploy-aws/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "deploy-aws"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "boto3~=1.42",
+    "botocore[crt]~=1.42",
+]
+
+[dependency-groups]
+dev = []

--- a/skills/deploy-aws/scripts/build-push.py
+++ b/skills/deploy-aws/scripts/build-push.py
@@ -59,13 +59,17 @@ def ecr_login(session: boto3.Session, region: str, account_id: str) -> None:
     ecr = session.client("ecr")
     token = ecr.get_authorization_token(registryIds=[account_id])
     import base64
+
     auth = token["authorizationData"][0]
     decoded = base64.b64decode(auth["authorizationToken"]).decode()
     username, password = decoded.split(":", 1)
     registry = auth["proxyEndpoint"]
-    run(["docker", "login", "--username", username, "--password-stdin", registry],
-        input=password.encode(), capture_output=True)
-    print(f"  Logged in to ECR registry")
+    run(
+        ["docker", "login", "--username", username, "--password-stdin", registry],
+        input=password.encode(),
+        capture_output=True,
+    )
+    print("  Logged in to ECR registry")
 
 
 def smoke_test(service: str, tag: str) -> None:
@@ -76,8 +80,8 @@ def smoke_test(service: str, tag: str) -> None:
     API smoke test: GET /api/health → {"status":"ok"}
     Web smoke test: GET / → 200 (nginx serving static assets)
     """
-    import urllib.request
     import urllib.error
+    import urllib.request
 
     host_port = 3001 if service == "api" else 3080
     container_port = 3001 if service == "api" else 80
@@ -94,16 +98,17 @@ def smoke_test(service: str, tag: str) -> None:
     print(f"\nSmoke testing '{service}' locally...")
     cid_result = subprocess.run(
         ["docker", "run", "-d", "--rm", "-p", f"{host_port}:{container_port}"] + env_args + [tag],
-        capture_output=True, text=True
+        capture_output=True,
+        text=True,
     )
     if cid_result.returncode != 0:
-        print(f"  ERROR: container failed to start", file=sys.stderr)
+        print("  ERROR: container failed to start", file=sys.stderr)
         print(cid_result.stderr, file=sys.stderr)
         sys.exit(1)
     cid = cid_result.stdout.strip()
 
     try:
-        for attempt in range(10):
+        for _attempt in range(10):
             time.sleep(2)
             try:
                 with urllib.request.urlopen(health_url, timeout=3) as resp:
@@ -114,7 +119,10 @@ def smoke_test(service: str, tag: str) -> None:
                 pass
         # Last attempt — show container logs before failing
         logs = subprocess.run(["docker", "logs", cid], capture_output=True, text=True)
-        print(f"  ERROR: smoke test failed — container did not respond at {health_url}", file=sys.stderr)
+        print(
+            f"  ERROR: smoke test failed — container did not respond at {health_url}",
+            file=sys.stderr,
+        )
         if logs.stdout or logs.stderr:
             print("  Container logs:", file=sys.stderr)
             print((logs.stdout + logs.stderr)[-1000:], file=sys.stderr)
@@ -131,7 +139,6 @@ def main():
     config = load_config()
     region = config["region"]
     account_id = config["account"]
-    app = config["app"]
     service = args.service
 
     svc_config = config.get("services", {}).get(service)
@@ -166,14 +173,21 @@ def main():
 
     print("\nBuilding and pushing linux/amd64 image to ECR...")
     ecr_login(session, region, account_id)
-    run([
-        "docker", "buildx", "build",
-        "--platform", "linux/amd64",
-        "-f", dockerfile,
-        "-t", tag,
-        "--push",
-        ".",
-    ])
+    run(
+        [
+            "docker",
+            "buildx",
+            "build",
+            "--platform",
+            "linux/amd64",
+            "-f",
+            dockerfile,
+            "-t",
+            tag,
+            "--push",
+            ".",
+        ]
+    )
 
     # Fetch the digest from the registry (buildx --push writes directly, no local image).
     # Compute digest from the raw manifest — the --format template is unreliable across
@@ -184,6 +198,7 @@ def main():
     )
     if result.returncode == 0 and result.stdout:
         import hashlib
+
         digest = f"sha256:{hashlib.sha256(result.stdout).hexdigest()}"
         image_uri = f"{ecr_repo}@{digest}"
     else:
@@ -195,7 +210,7 @@ def main():
     save_config(config)
 
     print(f"\n  Pushed: {image_uri}")
-    print(f"  Updated .deploy-aws.json\n")
+    print("  Updated .deploy-aws.json\n")
 
 
 if __name__ == "__main__":

--- a/skills/deploy-aws/scripts/build-push.py
+++ b/skills/deploy-aws/scripts/build-push.py
@@ -175,13 +175,19 @@ def main():
         ".",
     ])
 
-    # Fetch the digest from the registry (buildx --push writes directly, no local image)
+    # Fetch the digest from the registry (buildx --push writes directly, no local image).
+    # Compute digest from the raw manifest — the --format template is unreliable across
+    # Docker versions for multi-platform manifest lists.
     result = subprocess.run(
-        ["docker", "buildx", "imagetools", "inspect", tag, "--format", "{{.Manifest.Digest}}"],
-        capture_output=True, text=True
+        ["docker", "buildx", "imagetools", "inspect", tag, "--raw"],
+        capture_output=True,
     )
-    digest = result.stdout.strip()
-    image_uri = f"{ecr_repo}@{digest}" if digest else tag
+    if result.returncode == 0 and result.stdout:
+        import hashlib
+        digest = f"sha256:{hashlib.sha256(result.stdout).hexdigest()}"
+        image_uri = f"{ecr_repo}@{digest}"
+    else:
+        image_uri = tag
 
     # Update config
     config["services"][service]["image_uri"] = image_uri

--- a/skills/deploy-aws/scripts/build-push.py
+++ b/skills/deploy-aws/scripts/build-push.py
@@ -96,20 +96,26 @@ def main():
     # ECR login
     ecr_login(session, region, account_id)
 
-    # Build
-    print("\nBuilding image...")
-    run(["docker", "build", "-f", dockerfile, "-t", tag, "."])
+    # Build and push in one step, forcing linux/amd64 for App Runner compatibility.
+    # Critical on Apple Silicon — docker build defaults to arm64 which silently
+    # fails to start on App Runner's amd64 infrastructure.
+    print("\nBuilding and pushing image (linux/amd64)...")
+    run([
+        "docker", "buildx", "build",
+        "--platform", "linux/amd64",
+        "-f", dockerfile,
+        "-t", tag,
+        "--push",
+        ".",
+    ])
 
-    # Push
-    print("\nPushing image...")
-    run(["docker", "push", tag])
-
-    # Get the image digest for pinning
+    # Fetch the digest from the registry (buildx --push writes directly, no local image)
     result = subprocess.run(
-        ["docker", "inspect", "--format={{index .RepoDigests 0}}", tag],
+        ["docker", "buildx", "imagetools", "inspect", tag, "--format", "{{.Manifest.Digest}}"],
         capture_output=True, text=True
     )
-    image_uri = result.stdout.strip() if result.returncode == 0 and result.stdout.strip() else tag
+    digest = result.stdout.strip()
+    image_uri = f"{ecr_repo}@{digest}" if digest else tag
 
     # Update config
     config["services"][service]["image_uri"] = image_uri

--- a/skills/deploy-aws/scripts/build-push.py
+++ b/skills/deploy-aws/scripts/build-push.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+Build a Docker image and push it to ECR.
+Reads .deploy-aws.json for the ECR repo URI.
+Updates .deploy-aws.json with the pushed image URI.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import boto3
+
+
+def load_config() -> dict:
+    p = Path(".deploy-aws.json")
+    if not p.exists():
+        print("ERROR: .deploy-aws.json not found. Run provision.py first.", file=sys.stderr)
+        sys.exit(1)
+    return json.loads(p.read_text())
+
+
+def save_config(config: dict) -> None:
+    Path(".deploy-aws.json").write_text(json.dumps(config, indent=2) + "\n")
+
+
+def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    print(f"  $ {' '.join(cmd)}")
+    result = subprocess.run(cmd, **kwargs)
+    if result.returncode != 0:
+        print(f"ERROR: command failed (exit {result.returncode})", file=sys.stderr)
+        sys.exit(result.returncode)
+    return result
+
+
+def find_dockerfile(service: str, config: dict) -> str:
+    """Find the Dockerfile for a service. Checks config first, then common paths."""
+    svc_config = config.get("services", {}).get(service, {})
+    if "dockerfile" in svc_config:
+        return svc_config["dockerfile"]
+    candidates = [
+        f"apps/{service}/Dockerfile",
+        f"{service}/Dockerfile",
+        "Dockerfile",
+    ]
+    for c in candidates:
+        if Path(c).exists():
+            return c
+    print(f"ERROR: no Dockerfile found for service '{service}'", file=sys.stderr)
+    print(f"  Tried: {candidates}", file=sys.stderr)
+    sys.exit(1)
+
+
+def ecr_login(session: boto3.Session, region: str, account_id: str) -> None:
+    """Authenticate Docker to ECR."""
+    ecr = session.client("ecr")
+    token = ecr.get_authorization_token(registryIds=[account_id])
+    import base64
+    auth = token["authorizationData"][0]
+    decoded = base64.b64decode(auth["authorizationToken"]).decode()
+    username, password = decoded.split(":", 1)
+    registry = auth["proxyEndpoint"]
+    run(["docker", "login", "--username", username, "--password-stdin", registry],
+        input=password.encode(), capture_output=True)
+    print(f"  Logged in to ECR registry")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build and push a service image to ECR")
+    parser.add_argument("--service", required=True, help="Service name (e.g. api, web)")
+    args = parser.parse_args()
+
+    config = load_config()
+    region = config["region"]
+    account_id = config["account"]
+    app = config["app"]
+    service = args.service
+
+    svc_config = config.get("services", {}).get(service)
+    if not svc_config:
+        print(f"ERROR: service '{service}' not found in .deploy-aws.json", file=sys.stderr)
+        sys.exit(1)
+
+    ecr_repo = svc_config["ecr_repo"]
+    dockerfile = find_dockerfile(service, config)
+    tag = f"{ecr_repo}:latest"
+
+    print(f"\nBuilding and pushing '{service}'")
+    print(f"  Dockerfile: {dockerfile}")
+    print(f"  Target:     {tag}\n")
+
+    session = boto3.Session(region_name=region)
+
+    # ECR login
+    ecr_login(session, region, account_id)
+
+    # Build
+    print("\nBuilding image...")
+    run(["docker", "build", "-f", dockerfile, "-t", tag, "."])
+
+    # Push
+    print("\nPushing image...")
+    run(["docker", "push", tag])
+
+    # Get the image digest for pinning
+    result = subprocess.run(
+        ["docker", "inspect", "--format={{index .RepoDigests 0}}", tag],
+        capture_output=True, text=True
+    )
+    image_uri = result.stdout.strip() if result.returncode == 0 and result.stdout.strip() else tag
+
+    # Update config
+    config["services"][service]["image_uri"] = image_uri
+    config["services"][service]["dockerfile"] = dockerfile
+    save_config(config)
+
+    print(f"\n  Pushed: {image_uri}")
+    print(f"  Updated .deploy-aws.json\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/deploy-aws/scripts/build-push.py
+++ b/skills/deploy-aws/scripts/build-push.py
@@ -9,6 +9,7 @@ import argparse
 import json
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import boto3
@@ -67,6 +68,61 @@ def ecr_login(session: boto3.Session, region: str, account_id: str) -> None:
     print(f"  Logged in to ECR registry")
 
 
+def smoke_test(service: str, tag: str) -> None:
+    """Run the container locally and verify the health endpoint responds.
+
+    Uses native arch (fast on any machine). The API health endpoint doesn't
+    touch the DB so a dummy DATABASE_URL is sufficient.
+    API smoke test: GET /api/health → {"status":"ok"}
+    Web smoke test: GET / → 200 (nginx serving static assets)
+    """
+    import urllib.request
+    import urllib.error
+
+    host_port = 3001 if service == "api" else 3080
+    container_port = 3001 if service == "api" else 80
+    health_url = (
+        f"http://localhost:{host_port}/api/health"
+        if service == "api"
+        else f"http://localhost:{host_port}/"
+    )
+    env_args = ["-e", f"PORT={container_port}"]
+    if service == "api":
+        env_args += ["-e", "DATABASE_URL=postgresql://test:test@localhost:5432/test"]
+        env_args += ["-e", "NODE_ENV=production"]
+
+    print(f"\nSmoke testing '{service}' locally...")
+    cid_result = subprocess.run(
+        ["docker", "run", "-d", "--rm", "-p", f"{host_port}:{container_port}"] + env_args + [tag],
+        capture_output=True, text=True
+    )
+    if cid_result.returncode != 0:
+        print(f"  ERROR: container failed to start", file=sys.stderr)
+        print(cid_result.stderr, file=sys.stderr)
+        sys.exit(1)
+    cid = cid_result.stdout.strip()
+
+    try:
+        for attempt in range(10):
+            time.sleep(2)
+            try:
+                with urllib.request.urlopen(health_url, timeout=3) as resp:
+                    if resp.status < 400:
+                        print(f"  Smoke test passed ({resp.status} {health_url})")
+                        return
+            except (urllib.error.URLError, OSError):
+                pass
+        # Last attempt — show container logs before failing
+        logs = subprocess.run(["docker", "logs", cid], capture_output=True, text=True)
+        print(f"  ERROR: smoke test failed — container did not respond at {health_url}", file=sys.stderr)
+        if logs.stdout or logs.stderr:
+            print("  Container logs:", file=sys.stderr)
+            print((logs.stdout + logs.stderr)[-1000:], file=sys.stderr)
+        sys.exit(1)
+    finally:
+        subprocess.run(["docker", "stop", cid], capture_output=True)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Build and push a service image to ECR")
     parser.add_argument("--service", required=True, help="Service name (e.g. api, web)")
@@ -96,10 +152,20 @@ def main():
     # ECR login
     ecr_login(session, region, account_id)
 
-    # Build and push in one step, forcing linux/amd64 for App Runner compatibility.
-    # Critical on Apple Silicon — docker build defaults to arm64 which silently
-    # fails to start on App Runner's amd64 infrastructure.
-    print("\nBuilding and pushing image (linux/amd64)...")
+    # Build locally first for smoke test, then push amd64 to ECR.
+    # Local build uses native arch (fast, no emulation) — enough to verify startup.
+    # Push step forces linux/amd64 for App Runner compatibility (critical on Apple Silicon).
+    local_tag = f"{tag}-smoke"
+    print("\nBuilding image locally for smoke test...")
+    run(["docker", "build", "-f", dockerfile, "-t", local_tag, "."])
+
+    smoke_test(service, local_tag)
+
+    # Clean up local smoke image
+    subprocess.run(["docker", "rmi", local_tag], capture_output=True)
+
+    print("\nBuilding and pushing linux/amd64 image to ECR...")
+    ecr_login(session, region, account_id)
     run([
         "docker", "buildx", "build",
         "--platform", "linux/amd64",

--- a/skills/deploy-aws/scripts/cleanup.py
+++ b/skills/deploy-aws/scripts/cleanup.py
@@ -117,9 +117,9 @@ def delete_rds_instance(rds, identifier: str) -> None:
 def delete_security_group(ec2, sg_name: str) -> None:
     print(f"  Deleting security group: {sg_name}")
     try:
-        sgs = ec2.describe_security_groups(
-            Filters=[{"Name": "group-name", "Values": [sg_name]}]
-        )["SecurityGroups"]
+        sgs = ec2.describe_security_groups(Filters=[{"Name": "group-name", "Values": [sg_name]}])[
+            "SecurityGroups"
+        ]
     except ClientError:
         raise
 
@@ -148,9 +148,7 @@ def delete_iam_role(iam, role_arn: str) -> None:
 
     # Detach managed policies first
     try:
-        attached = iam.list_attached_role_policies(RoleName=role_name)[
-            "AttachedPolicies"
-        ]
+        attached = iam.list_attached_role_policies(RoleName=role_name)["AttachedPolicies"]
         for policy in attached:
             print(f"    Detaching policy: {policy['PolicyName']}")
             iam.detach_role_policy(RoleName=role_name, PolicyArn=policy["PolicyArn"])

--- a/skills/deploy-aws/scripts/cleanup.py
+++ b/skills/deploy-aws/scripts/cleanup.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""
+Tear down all AWS resources provisioned by deploy-aws.
+Reads .deploy-aws.json from the current directory and deletes resources
+in the correct order (App Runner → ECR → RDS → security group → IAM).
+"""
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import boto3
+from botocore.exceptions import ClientError
+
+ECR_ACCESS_POLICY_ARN = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+
+
+def load_config() -> dict:
+    p = Path(".deploy-aws.json")
+    if not p.exists():
+        print("Error: .deploy-aws.json not found in the current directory.")
+        print("Run this from the project root where you originally deployed from.")
+        sys.exit(1)
+    return json.loads(p.read_text())
+
+
+# ── App Runner ────────────────────────────────────────────────────────────────
+
+
+def delete_apprunner_service(apprunner, arn: str, name: str) -> None:
+    print(f"  Deleting App Runner service: {name}")
+    try:
+        apprunner.delete_service(ServiceArn=arn)
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        if code in ("ResourceNotFoundException", "InvalidStateException"):
+            # InvalidStateException can fire if already in DELETED state
+            msg = e.response["Error"]["Message"]
+            if "DELETED" in msg or "not found" in msg.lower():
+                print(f"    Already deleted: {name}")
+                return
+        raise
+
+    # App Runner has no delete waiter — poll manually
+    print(f"    Waiting for {name} to be deleted (up to ~3 min)...")
+    for attempt in range(20):
+        time.sleep(10)
+        try:
+            resp = apprunner.describe_service(ServiceArn=arn)
+            status = resp["Service"]["Status"]
+            if status == "DELETED":
+                print(f"    Deleted: {name}")
+                return
+            print(f"    Status: {status} (attempt {attempt + 1}/20)")
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "ResourceNotFoundException":
+                print(f"    Deleted: {name}")
+                return
+            raise
+
+    print(f"  Warning: timed out waiting for {name} to delete — continuing anyway")
+
+
+# ── ECR ──────────────────────────────────────────────────────────────────────
+
+
+def parse_ecr_repo_name(uri: str) -> str:
+    """Extract repo name from a full ECR URI.
+
+    Example: 886511954473.dkr.ecr.us-east-1.amazonaws.com/test-graphql-api
+             → test-graphql-api
+    """
+    return uri.split("/", 1)[-1]
+
+
+def delete_ecr_repo(ecr, uri: str) -> None:
+    repo_name = parse_ecr_repo_name(uri)
+    print(f"  Deleting ECR repo: {repo_name}")
+    try:
+        ecr.delete_repository(repositoryName=repo_name, force=True)
+        print(f"    Deleted: {repo_name}")
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "RepositoryNotFoundException":
+            print(f"    Already deleted: {repo_name}")
+        else:
+            raise
+
+
+# ── RDS ──────────────────────────────────────────────────────────────────────
+
+
+def delete_rds_instance(rds, identifier: str) -> None:
+    print(f"  Deleting RDS instance: {identifier}")
+    try:
+        rds.delete_db_instance(
+            DBInstanceIdentifier=identifier,
+            SkipFinalSnapshot=True,
+            DeleteAutomatedBackups=True,
+        )
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "DBInstanceNotFound":
+            print(f"    Already deleted: {identifier}")
+            return
+        raise
+
+    print(f"    Waiting for {identifier} to be deleted (this can take 3-5 min)...")
+    waiter = rds.get_waiter("db_instance_deleted")
+    waiter.wait(
+        DBInstanceIdentifier=identifier,
+        WaiterConfig={"Delay": 15, "MaxAttempts": 40},
+    )
+    print(f"    Deleted: {identifier}")
+
+
+def delete_security_group(ec2, sg_name: str) -> None:
+    print(f"  Deleting security group: {sg_name}")
+    try:
+        sgs = ec2.describe_security_groups(
+            Filters=[{"Name": "group-name", "Values": [sg_name]}]
+        )["SecurityGroups"]
+    except ClientError:
+        raise
+
+    if not sgs:
+        print(f"    Already deleted: {sg_name}")
+        return
+
+    sg_id = sgs[0]["GroupId"]
+    try:
+        ec2.delete_security_group(GroupId=sg_id)
+        print(f"    Deleted: {sg_name} ({sg_id})")
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "InvalidGroup.NotFound":
+            print(f"    Already deleted: {sg_name}")
+        else:
+            raise
+
+
+# ── IAM ──────────────────────────────────────────────────────────────────────
+
+
+def delete_iam_role(iam, role_arn: str) -> None:
+    # Extract role name from ARN: arn:aws:iam::123:role/my-role-name
+    role_name = role_arn.split("/")[-1]
+    print(f"  Deleting IAM role: {role_name}")
+
+    # Detach managed policies first
+    try:
+        attached = iam.list_attached_role_policies(RoleName=role_name)[
+            "AttachedPolicies"
+        ]
+        for policy in attached:
+            print(f"    Detaching policy: {policy['PolicyName']}")
+            iam.detach_role_policy(RoleName=role_name, PolicyArn=policy["PolicyArn"])
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "NoSuchEntity":
+            print(f"    Already deleted: {role_name}")
+            return
+        raise
+
+    try:
+        iam.delete_role(RoleName=role_name)
+        print(f"    Deleted: {role_name}")
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "NoSuchEntity":
+            print(f"    Already deleted: {role_name}")
+        else:
+            raise
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Tear down AWS resources provisioned by deploy-aws"
+    )
+    parser.add_argument(
+        "--keep-config",
+        action="store_true",
+        help="Keep .deploy-aws.json after cleanup (default: delete it)",
+    )
+    args = parser.parse_args()
+
+    config = load_config()
+    app = config["app"]
+    region = config["region"]
+    services = config.get("services", {})
+    database = config.get("database", {})
+    iam_role_arn = config.get("iam_role_arn")
+
+    session = boto3.Session(region_name=region)
+
+    print(f"\nCleaning up AWS resources for '{app}' in {region}")
+    print("=" * 55)
+
+    # 1. App Runner services
+    if services:
+        print("\nApp Runner services:")
+        apprunner = session.client("apprunner")
+        for svc_name, svc_info in services.items():
+            arn = svc_info.get("apprunner_arn")
+            if arn:
+                delete_apprunner_service(apprunner, arn, f"{app}-{svc_name}")
+            else:
+                print(f"  Skipping {svc_name} — no apprunner_arn in config")
+
+    # 2. ECR repos
+    if services:
+        print("\nECR repositories:")
+        ecr = session.client("ecr")
+        for svc_name, svc_info in services.items():
+            uri = svc_info.get("ecr_repo")
+            if uri:
+                delete_ecr_repo(ecr, uri)
+            else:
+                print(f"  Skipping {svc_name} — no ecr_repo in config")
+
+    # 3. RDS instance (only if provisioned by us, not external)
+    if database and database.get("identifier"):
+        print("\nRDS instance:")
+        rds = session.client("rds")
+        delete_rds_instance(rds, database["identifier"])
+
+        # 4. Security group (only after RDS is gone)
+        print("\nSecurity group:")
+        ec2 = session.client("ec2")
+        delete_security_group(ec2, f"{app}-rds-sg")
+
+    # 5. IAM role
+    if iam_role_arn:
+        print("\nIAM role:")
+        iam = session.client("iam")
+        delete_iam_role(iam, iam_role_arn)
+
+    # 6. Config file
+    if not args.keep_config:
+        Path(".deploy-aws.json").unlink(missing_ok=True)
+        print("\nDeleted .deploy-aws.json")
+    else:
+        print("\nKept .deploy-aws.json (--keep-config)")
+
+    print("\n── Cleanup complete ────────────────────────────────")
+    print(f"  All '{app}' resources removed from {region}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/deploy-aws/scripts/context.sh
+++ b/skills/deploy-aws/scripts/context.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Pre-loads deploy context for the SKILL.md prompt
+
+case "$1" in
+  auth-status)
+    aws sts get-caller-identity 2>/dev/null || echo '{"error": "not authenticated"}'
+    ;;
+
+  dockerfiles)
+    # Find Dockerfiles, exclude node_modules/.git, output as JSON array of relative paths
+    find . -name "Dockerfile" \
+      -not -path "*/node_modules/*" \
+      -not -path "*/.git/*" \
+      -not -path "*/dist/*" \
+      2>/dev/null \
+      | sort \
+      | sed 's|^\./||' \
+      | python3 -c "
+import sys, json
+files = [l.strip() for l in sys.stdin if l.strip()]
+# Annotate with service name derived from path
+services = []
+for f in files:
+    parts = f.split('/')
+    # apps/api/Dockerfile -> api, apps/web/Dockerfile -> web, Dockerfile -> app
+    if len(parts) >= 3 and parts[0] == 'apps':
+        name = parts[1]
+    elif len(parts) == 1:
+        name = 'app'
+    else:
+        name = parts[-2]
+    services.append({'name': name, 'dockerfile': f})
+print(json.dumps(services, indent=2))
+"
+    ;;
+
+  deploy-config)
+    if [ -f .deploy-aws.json ]; then
+      cat .deploy-aws.json
+    else
+      echo '{}'
+    fi
+    ;;
+
+  template-type)
+    python3 - <<'PYEOF'
+import os, json
+
+def detect():
+    has_pkg = os.path.exists('package.json')
+    has_pyproject = os.path.exists('pyproject.toml')
+    has_apps_api = os.path.exists('apps/api')
+    has_apps_web = os.path.exists('apps/web')
+
+    if has_pkg and has_pyproject:
+        return 'fullstack-python'
+    if has_pyproject and not has_pkg:
+        return 'api-python'
+    if has_pkg:
+        # Check for GraphQL markers
+        if os.path.exists('apps/api/src/yoga.ts') or os.path.exists('apps/api/src/schema.ts'):
+            return 'fullstack-graphql'
+        if has_apps_api and has_apps_web:
+            return 'fullstack-ts'
+        if has_apps_api and not has_apps_web:
+            return 'api-ts'
+    return 'unknown'
+
+print(detect())
+PYEOF
+    ;;
+
+  *)
+    echo "Usage: context.sh <auth-status|dockerfiles|deploy-config|template-type>" >&2
+    exit 1
+    ;;
+esac

--- a/skills/deploy-aws/scripts/deploy.py
+++ b/skills/deploy-aws/scripts/deploy.py
@@ -36,7 +36,6 @@ def service_name(app: str, service: str) -> str:
 def build_env_vars(service: str, config: dict) -> list[dict]:
     """Build environment variable list for the App Runner service."""
     env = []
-    app = config["app"]
     db = config.get("database")
 
     if service == "api":
@@ -57,8 +56,9 @@ def build_env_vars(service: str, config: dict) -> list[dict]:
     return env
 
 
-def find_or_create_service(apprunner, svc_name: str, image_uri: str,
-                            role_arn: str, port: int, env_vars: list[dict]) -> tuple[str, str]:
+def find_or_create_service(
+    apprunner, svc_name: str, image_uri: str, role_arn: str, port: int, env_vars: list[dict]
+) -> tuple[str, str]:
     """Create or update App Runner service. Returns (service_arn, status)."""
     # Check if service exists
     try:
@@ -71,7 +71,7 @@ def find_or_create_service(apprunner, svc_name: str, image_uri: str,
 
                 if status == "CREATE_FAILED":
                     # Delete the failed service and recreate fresh
-                    print(f"  Service is in CREATE_FAILED — deleting before recreating...")
+                    print("  Service is in CREATE_FAILED — deleting before recreating...")
                     apprunner.delete_service(ServiceArn=arn)
                     # Poll until deleted
                     for _ in range(30):
@@ -79,9 +79,12 @@ def find_or_create_service(apprunner, svc_name: str, image_uri: str,
                         try:
                             apprunner.describe_service(ServiceArn=arn)
                         except ClientError as e:
-                            if "ResourceNotFoundException" in str(e) or "does not exist" in str(e).lower():
+                            if (
+                                "ResourceNotFoundException" in str(e)
+                                or "does not exist" in str(e).lower()
+                            ):
                                 break
-                    print(f"  Deleted. Creating fresh service...")
+                    print("  Deleted. Creating fresh service...")
                     break  # fall through to create
 
                 # Update the existing service
@@ -93,14 +96,16 @@ def find_or_create_service(apprunner, svc_name: str, image_uri: str,
                             "ImageRepositoryType": "ECR",
                             "ImageConfiguration": {
                                 "Port": str(port),
-                                "RuntimeEnvironmentVariables": {v["name"]: v["value"] for v in env_vars},
+                                "RuntimeEnvironmentVariables": {
+                                    v["name"]: v["value"] for v in env_vars
+                                },
                             },
                         },
                         "AuthenticationConfiguration": {"AccessRoleArn": role_arn},
                         "AutoDeploymentsEnabled": False,
                     },
                 )
-                print(f"  Triggered update")
+                print("  Triggered update")
                 return arn, "UPDATING"
     except ClientError as e:
         print(f"  Warning: could not list services: {e}")
@@ -133,7 +138,9 @@ def get_apprunner_events(apprunner, service_arn: str, max_lines: int = 10) -> li
         resp = apprunner.list_operations(ServiceArn=service_arn)
         events = []
         for op in resp.get("OperationSummaryList", [])[:3]:
-            events.append(f"  [{op.get('Status','?')}] {op.get('Type','?')} @ {op.get('StartedAt','?')}")
+            events.append(
+                f"  [{op.get('Status', '?')}] {op.get('Type', '?')} @ {op.get('StartedAt', '?')}"
+            )
         return events
     except Exception:
         return []
@@ -145,7 +152,7 @@ def wait_for_running(apprunner, service_arn: str, timeout_s: int = 1200) -> str:
     First deploys typically take 10-20 minutes on App Runner.
     Prints recent events log on timeout for diagnostics.
     """
-    print(f"  Waiting for service to reach RUNNING state (timeout: {timeout_s//60}m)...")
+    print(f"  Waiting for service to reach RUNNING state (timeout: {timeout_s // 60}m)...")
     deadline = time.time() + timeout_s
     last_status = None
     while time.time() < deadline:
@@ -169,7 +176,7 @@ def wait_for_running(apprunner, service_arn: str, timeout_s: int = 1200) -> str:
             sys.exit(1)
         time.sleep(10)
 
-    print(f"ERROR: timed out after {timeout_s//60}m waiting for RUNNING", file=sys.stderr)
+    print(f"ERROR: timed out after {timeout_s // 60}m waiting for RUNNING", file=sys.stderr)
     events = get_apprunner_events(apprunner, service_arn)
     if events:
         print("Recent events:", file=sys.stderr)
@@ -191,9 +198,9 @@ def verify_deployment(service: str, url: str) -> None:
       2. Playwright: load URL in headless browser, wait for "API status: ok" rendered text
          (confirms browser JS → API → DB full stack, not just proxy connectivity)
     """
-    import urllib.request
-    import urllib.error
     import json as _json
+    import urllib.error
+    import urllib.request
 
     print(f"\n  Verifying deployment at {url}...")
 
@@ -240,12 +247,17 @@ def verify_deployment(service: str, url: str) -> None:
         if result is None:
             # Not a GraphQL service — try tRPC
             try:
-                ok, body = get("/api/trpc/user.list?input=%7B%22json%22%3Anull%7D", "tRPC user.list")
+                ok, body = get(
+                    "/api/trpc/user.list?input=%7B%22json%22%3Anull%7D", "tRPC user.list"
+                )
                 if ok:
                     data = _json.loads(body)
-                    emails = [u.get("email", "") for u in (data.get("result", {}).get("data", {}).get("json") or [])]
+                    emails = [
+                        u.get("email", "")
+                        for u in (data.get("result", {}).get("data", {}).get("json") or [])
+                    ]
                     if "alice@example.com" in emails and "bob@example.com" in emails:
-                        print(f"  ✓ Seed data present (alice, bob)")
+                        print("  ✓ Seed data present (alice, bob)")
                     else:
                         print(f"  ✗ Seed data missing — got: {emails[:5]}", file=sys.stderr)
             except Exception as e:
@@ -254,7 +266,7 @@ def verify_deployment(service: str, url: str) -> None:
             users = result.get("data", {}).get("users", [])
             emails = [u.get("email", "") for u in users]
             if "alice@example.com" in emails and "bob@example.com" in emails:
-                print(f"  ✓ Seed data present (alice, bob) via GraphQL")
+                print("  ✓ Seed data present (alice, bob) via GraphQL")
             else:
                 print(f"  ✗ Seed data missing — got: {emails[:5]}", file=sys.stderr)
 
@@ -263,16 +275,19 @@ def verify_deployment(service: str, url: str) -> None:
         get("/api/health", "GET /api/health (via nginx proxy)")
 
         # 2. Playwright — load the real page, confirm the React app renders API data
-        print(f"  Launching headless browser to verify rendered UI...")
+        print("  Launching headless browser to verify rendered UI...")
         try:
-            from playwright.sync_api import sync_playwright, Error as PlaywrightError
+            from playwright.sync_api import Error as PlaywrightError
+            from playwright.sync_api import sync_playwright
+
             with sync_playwright() as pw:
                 # Install chromium if missing (first run after deploy-aws env setup)
                 try:
                     browser = pw.chromium.launch(headless=True)
                 except Exception:
                     import subprocess
-                    print(f"  Installing Chromium (first run)...")
+
+                    print("  Installing Chromium (first run)...")
                     subprocess.run(
                         ["python", "-m", "playwright", "install", "chromium"],
                         capture_output=True,
@@ -282,22 +297,35 @@ def verify_deployment(service: str, url: str) -> None:
                 page = browser.new_page()
                 page.goto(url, timeout=30000)
                 try:
-                    # Both fullstack-ts (tRPC) and fullstack-graphql show this text when API is reachable
+                    # Both fullstack-ts (tRPC) and fullstack-graphql show this
+                    # text when API is reachable
                     page.wait_for_selector("text=API status: ok", timeout=20000)
-                    print(f"  ✓ Browser rendered 'API status: ok' (web → API → DB confirmed)")
+                    print("  ✓ Browser rendered 'API status: ok' (web → API → DB confirmed)")
                 except PlaywrightError:
                     content = page.content()
                     # Look for error state
                     if "API status: error" in content:
-                        print(f"  ✗ Browser shows 'API status: error' — web cannot reach API", file=sys.stderr)
+                        print(
+                            "  ✗ Browser shows 'API status: error' — web cannot reach API",
+                            file=sys.stderr,
+                        )
                     elif "API status: loading" in content:
-                        print(f"  ✗ Browser stuck on 'loading...' — API call timed out", file=sys.stderr)
+                        print(
+                            "  ✗ Browser stuck on 'loading...' — API call timed out",
+                            file=sys.stderr,
+                        )
                     else:
-                        print(f"  ✗ Expected 'API status: ok' not found in rendered page", file=sys.stderr)
+                        print(
+                            "  ✗ Expected 'API status: ok' not found in rendered page",
+                            file=sys.stderr,
+                        )
                 finally:
                     browser.close()
         except ImportError:
-            print(f"  ~ Playwright not installed — skipping browser check (run: uv sync in skills/deploy-aws)")
+            print(
+                "  ~ Playwright not installed — skipping browser check"
+                " (run: uv sync in skills/deploy-aws)"
+            )
 
 
 def main():
@@ -322,7 +350,9 @@ def main():
 
     role_arn = config.get("iam_role_arn")
     if not role_arn:
-        print("ERROR: iam_role_arn not in .deploy-aws.json — run provision.py first", file=sys.stderr)
+        print(
+            "ERROR: iam_role_arn not in .deploy-aws.json — run provision.py first", file=sys.stderr
+        )
         sys.exit(1)
 
     # Port: api runs on 3001, web nginx on 80

--- a/skills/deploy-aws/scripts/deploy.py
+++ b/skills/deploy-aws/scripts/deploy.py
@@ -179,12 +179,17 @@ def wait_for_running(apprunner, service_arn: str, timeout_s: int = 1200) -> str:
 
 
 def verify_deployment(service: str, url: str) -> None:
-    """Hit health endpoints to confirm the deployment is actually serving traffic.
+    """Verify the deployment end-to-end — not just that the container is up.
 
-    RUNNING status only means the container is up — this confirms it responds correctly.
-    API: GET /api/health → {"status":"ok"}
-    Web: GET / → 200 + also checks /api/health proxies correctly
-    GraphQL: POST /api/graphql with { health } query as a bonus check
+    API checks:
+      1. GET /api/health → {"status":"ok"} or "ok"
+      2a. GraphQL: POST /api/graphql { users { email } } → alice + bob in seed data (DB check)
+      2b. tRPC fallback: GET /api/trpc/user.list → alice + bob (if not GraphQL)
+
+    Web checks:
+      1. GET /api/health via nginx proxy (confirms nginx → API routing works)
+      2. Playwright: load URL in headless browser, wait for "API status: ok" rendered text
+         (confirms browser JS → API → DB full stack, not just proxy connectivity)
     """
     import urllib.request
     import urllib.error
@@ -192,7 +197,7 @@ def verify_deployment(service: str, url: str) -> None:
 
     print(f"\n  Verifying deployment at {url}...")
 
-    def get(path: str, label: str) -> bool:
+    def get(path: str, label: str):
         try:
             with urllib.request.urlopen(f"{url}{path}", timeout=10) as resp:
                 body = resp.read().decode()
@@ -205,30 +210,94 @@ def verify_deployment(service: str, url: str) -> None:
             print(f"  ✗ {label} ({e})", file=sys.stderr)
             return False, ""
 
-    if service == "api":
-        ok, body = get("/api/health", "GET /api/health")
-        if ok and '"ok"' not in body:
-            print(f"  ✗ Health response unexpected: {body[:100]}", file=sys.stderr)
-        # GraphQL health query
+    def graphql(query: str, label: str):
         try:
-            data = _json.dumps({"query": "{ health }"}).encode()
+            data = _json.dumps({"query": query}).encode()
             req = urllib.request.Request(
                 f"{url}/api/graphql",
                 data=data,
                 headers={"Content-Type": "application/json"},
             )
             with urllib.request.urlopen(req, timeout=10) as resp:
-                result = _json.loads(resp.read())
-                if result.get("data", {}).get("health"):
-                    print(f"  ✓ GraphQL {{ health }} query")
-                else:
-                    print(f"  ~ GraphQL query returned: {str(result)[:100]}")
+                return _json.loads(resp.read())
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                return None  # not a GraphQL service
+            print(f"  ✗ {label} (HTTP {e.code})", file=sys.stderr)
+            return {}
         except Exception as e:
-            print(f"  ~ GraphQL check skipped ({e})")
+            print(f"  ✗ {label} ({e})", file=sys.stderr)
+            return {}
+
+    if service == "api":
+        # 1. Health endpoint
+        ok, body = get("/api/health", "GET /api/health")
+        if ok and '"ok"' not in body and "'ok'" not in body and "ok" not in body.lower():
+            print(f"  ✗ Health response unexpected: {body[:100]}", file=sys.stderr)
+
+        # 2. Seed data check — confirms API → DB connectivity with real data
+        result = graphql("{ users { email } }", "GraphQL users query")
+        if result is None:
+            # Not a GraphQL service — try tRPC
+            try:
+                ok, body = get("/api/trpc/user.list?input=%7B%22json%22%3Anull%7D", "tRPC user.list")
+                if ok:
+                    data = _json.loads(body)
+                    emails = [u.get("email", "") for u in (data.get("result", {}).get("data", {}).get("json") or [])]
+                    if "alice@example.com" in emails and "bob@example.com" in emails:
+                        print(f"  ✓ Seed data present (alice, bob)")
+                    else:
+                        print(f"  ✗ Seed data missing — got: {emails[:5]}", file=sys.stderr)
+            except Exception as e:
+                print(f"  ~ Data check skipped: {e}")
+        elif result:
+            users = result.get("data", {}).get("users", [])
+            emails = [u.get("email", "") for u in users]
+            if "alice@example.com" in emails and "bob@example.com" in emails:
+                print(f"  ✓ Seed data present (alice, bob) via GraphQL")
+            else:
+                print(f"  ✗ Seed data missing — got: {emails[:5]}", file=sys.stderr)
 
     elif service == "web":
-        get("/", "GET / (web app)")
+        # 1. Proxy check — confirms nginx routes /api/ to the API service
         get("/api/health", "GET /api/health (via nginx proxy)")
+
+        # 2. Playwright — load the real page, confirm the React app renders API data
+        print(f"  Launching headless browser to verify rendered UI...")
+        try:
+            from playwright.sync_api import sync_playwright, Error as PlaywrightError
+            with sync_playwright() as pw:
+                # Install chromium if missing (first run after deploy-aws env setup)
+                try:
+                    browser = pw.chromium.launch(headless=True)
+                except Exception:
+                    import subprocess
+                    print(f"  Installing Chromium (first run)...")
+                    subprocess.run(
+                        ["python", "-m", "playwright", "install", "chromium"],
+                        capture_output=True,
+                    )
+                    browser = pw.chromium.launch(headless=True)
+
+                page = browser.new_page()
+                page.goto(url, timeout=30000)
+                try:
+                    # Both fullstack-ts (tRPC) and fullstack-graphql show this text when API is reachable
+                    page.wait_for_selector("text=API status: ok", timeout=20000)
+                    print(f"  ✓ Browser rendered 'API status: ok' (web → API → DB confirmed)")
+                except PlaywrightError:
+                    content = page.content()
+                    # Look for error state
+                    if "API status: error" in content:
+                        print(f"  ✗ Browser shows 'API status: error' — web cannot reach API", file=sys.stderr)
+                    elif "API status: loading" in content:
+                        print(f"  ✗ Browser stuck on 'loading...' — API call timed out", file=sys.stderr)
+                    else:
+                        print(f"  ✗ Expected 'API status: ok' not found in rendered page", file=sys.stderr)
+                finally:
+                    browser.close()
+        except ImportError:
+            print(f"  ~ Playwright not installed — skipping browser check (run: uv sync in skills/deploy-aws)")
 
 
 def main():

--- a/skills/deploy-aws/scripts/deploy.py
+++ b/skills/deploy-aws/scripts/deploy.py
@@ -178,6 +178,59 @@ def wait_for_running(apprunner, service_arn: str, timeout_s: int = 1200) -> str:
     sys.exit(1)
 
 
+def verify_deployment(service: str, url: str) -> None:
+    """Hit health endpoints to confirm the deployment is actually serving traffic.
+
+    RUNNING status only means the container is up — this confirms it responds correctly.
+    API: GET /api/health → {"status":"ok"}
+    Web: GET / → 200 + also checks /api/health proxies correctly
+    GraphQL: POST /api/graphql with { health } query as a bonus check
+    """
+    import urllib.request
+    import urllib.error
+    import json as _json
+
+    print(f"\n  Verifying deployment at {url}...")
+
+    def get(path: str, label: str) -> bool:
+        try:
+            with urllib.request.urlopen(f"{url}{path}", timeout=10) as resp:
+                body = resp.read().decode()
+                print(f"  ✓ {label} ({resp.status})")
+                return True, body
+        except urllib.error.HTTPError as e:
+            print(f"  ✗ {label} (HTTP {e.code})", file=sys.stderr)
+            return False, ""
+        except Exception as e:
+            print(f"  ✗ {label} ({e})", file=sys.stderr)
+            return False, ""
+
+    if service == "api":
+        ok, body = get("/api/health", "GET /api/health")
+        if ok and '"ok"' not in body:
+            print(f"  ✗ Health response unexpected: {body[:100]}", file=sys.stderr)
+        # GraphQL health query
+        try:
+            data = _json.dumps({"query": "{ health }"}).encode()
+            req = urllib.request.Request(
+                f"{url}/api/graphql",
+                data=data,
+                headers={"Content-Type": "application/json"},
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                result = _json.loads(resp.read())
+                if result.get("data", {}).get("health"):
+                    print(f"  ✓ GraphQL {{ health }} query")
+                else:
+                    print(f"  ~ GraphQL query returned: {str(result)[:100]}")
+        except Exception as e:
+            print(f"  ~ GraphQL check skipped ({e})")
+
+    elif service == "web":
+        get("/", "GET / (web app)")
+        get("/api/health", "GET /api/health (via nginx proxy)")
+
+
 def main():
     parser = argparse.ArgumentParser(description="Deploy a service to App Runner")
     parser.add_argument("--service", required=True, help="Service name (e.g. api, web)")
@@ -226,6 +279,8 @@ def main():
     )
 
     url = wait_for_running(apprunner, service_arn)
+
+    verify_deployment(service, url)
 
     # Save URL and ARN to config
     config["services"][service]["url"] = url

--- a/skills/deploy-aws/scripts/deploy.py
+++ b/skills/deploy-aws/scripts/deploy.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""
+Create or update an App Runner service for a given service.
+Reads state from .deploy-aws.json and writes back the live URL.
+
+Service ordering: always deploy API before web. The web service needs
+the API's live URL to set API_HOST correctly.
+"""
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import boto3
+from botocore.exceptions import ClientError
+
+
+def load_config() -> dict:
+    p = Path(".deploy-aws.json")
+    if not p.exists():
+        print("ERROR: .deploy-aws.json not found. Run provision.py first.", file=sys.stderr)
+        sys.exit(1)
+    return json.loads(p.read_text())
+
+
+def save_config(config: dict) -> None:
+    Path(".deploy-aws.json").write_text(json.dumps(config, indent=2) + "\n")
+
+
+def service_name(app: str, service: str) -> str:
+    return f"{app}-{service}"
+
+
+def build_env_vars(service: str, config: dict) -> list[dict]:
+    """Build environment variable list for the App Runner service."""
+    env = []
+    app = config["app"]
+    db = config.get("database")
+
+    if service == "api":
+        # PORT that the API listens on
+        env.append({"name": "PORT", "value": "3001"})
+        env.append({"name": "NODE_ENV", "value": "production"})
+        if db and "url" in db:
+            env.append({"name": "DATABASE_URL", "value": db["url"]})
+
+    elif service == "web":
+        # API_HOST: URL of the deployed API service (no trailing slash)
+        api_url = config.get("services", {}).get("api", {}).get("url", "")
+        if api_url:
+            env.append({"name": "API_HOST", "value": api_url.rstrip("/")})
+        else:
+            print("  WARNING: API URL not found in config — API_HOST will not be set")
+
+    return env
+
+
+def find_or_create_service(apprunner, svc_name: str, image_uri: str,
+                            role_arn: str, port: int, env_vars: list[dict]) -> tuple[str, str]:
+    """Create or update App Runner service. Returns (service_arn, status)."""
+    # Check if service exists
+    try:
+        resp = apprunner.list_services()
+        for svc in resp.get("ServiceSummaryList", []):
+            if svc["ServiceName"] == svc_name:
+                arn = svc["ServiceArn"]
+                print(f"  Service exists: {arn}")
+                # Update the service with the new image
+                apprunner.update_service(
+                    ServiceArn=arn,
+                    SourceConfiguration={
+                        "ImageRepository": {
+                            "ImageIdentifier": image_uri,
+                            "ImageRepositoryType": "ECR",
+                            "ImageConfiguration": {
+                                "Port": str(port),
+                                "RuntimeEnvironmentVariables": {v["name"]: v["value"] for v in env_vars},
+                            },
+                        },
+                        "AuthenticationConfiguration": {"AccessRoleArn": role_arn},
+                        "AutoDeploymentsEnabled": False,
+                    },
+                )
+                print(f"  Triggered update")
+                return arn, "UPDATING"
+    except ClientError as e:
+        print(f"  Warning: could not list services: {e}")
+
+    # Create new service
+    resp = apprunner.create_service(
+        ServiceName=svc_name,
+        SourceConfiguration={
+            "ImageRepository": {
+                "ImageIdentifier": image_uri,
+                "ImageRepositoryType": "ECR",
+                "ImageConfiguration": {
+                    "Port": str(port),
+                    "RuntimeEnvironmentVariables": {v["name"]: v["value"] for v in env_vars},
+                },
+            },
+            "AuthenticationConfiguration": {"AccessRoleArn": role_arn},
+            "AutoDeploymentsEnabled": False,
+        },
+        InstanceConfiguration={"Cpu": "0.25 vCPU", "Memory": "0.5 GB"},
+    )
+    arn = resp["Service"]["ServiceArn"]
+    print(f"  Created service: {arn}")
+    return arn, "CREATING"
+
+
+def wait_for_running(apprunner, service_arn: str, timeout_s: int = 300) -> str:
+    """Poll until service reaches RUNNING. Returns the service URL."""
+    print(f"  Waiting for service to reach RUNNING state...")
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        resp = apprunner.describe_service(ServiceArn=service_arn)
+        svc = resp["Service"]
+        status = svc["Status"]
+        url = svc.get("ServiceUrl", "")
+        print(f"    Status: {status}")
+        if status == "RUNNING":
+            return f"https://{url}"
+        if status in ("CREATE_FAILED", "DELETE_FAILED", "OPERATION_IN_PROGRESS"):
+            if status not in ("OPERATION_IN_PROGRESS",):
+                print(f"ERROR: service entered {status} state", file=sys.stderr)
+                sys.exit(1)
+        time.sleep(10)
+    print(f"ERROR: timed out waiting for service to reach RUNNING after {timeout_s}s", file=sys.stderr)
+    sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Deploy a service to App Runner")
+    parser.add_argument("--service", required=True, help="Service name (e.g. api, web)")
+    args = parser.parse_args()
+
+    config = load_config()
+    region = config["region"]
+    app = config["app"]
+    service = args.service
+
+    svc_config = config.get("services", {}).get(service)
+    if not svc_config:
+        print(f"ERROR: service '{service}' not in .deploy-aws.json", file=sys.stderr)
+        sys.exit(1)
+
+    image_uri = svc_config.get("image_uri")
+    if not image_uri:
+        print(f"ERROR: no image_uri for '{service}' — run build-push.py first", file=sys.stderr)
+        sys.exit(1)
+
+    role_arn = config.get("iam_role_arn")
+    if not role_arn:
+        print("ERROR: iam_role_arn not in .deploy-aws.json — run provision.py first", file=sys.stderr)
+        sys.exit(1)
+
+    # Port: api runs on 3001, web nginx on 80
+    port = 3001 if service == "api" else 80
+
+    env_vars = build_env_vars(service, config)
+    svc_name = service_name(app, service)
+
+    print(f"\nDeploying '{service}' to App Runner")
+    print(f"  Service name: {svc_name}")
+    print(f"  Image: {image_uri}")
+    if env_vars:
+        for v in env_vars:
+            display = "***" if v["name"] in ("DATABASE_URL",) else v["value"]
+            print(f"  Env: {v['name']}={display}")
+    print()
+
+    session = boto3.Session(region_name=region)
+    apprunner = session.client("apprunner")
+
+    service_arn, _ = find_or_create_service(
+        apprunner, svc_name, image_uri, role_arn, port, env_vars
+    )
+
+    url = wait_for_running(apprunner, service_arn)
+
+    # Save URL and ARN to config
+    config["services"][service]["url"] = url
+    config["services"][service]["apprunner_arn"] = service_arn
+    save_config(config)
+
+    print(f"\n  Live: {url}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/deploy-aws/scripts/deploy.py
+++ b/skills/deploy-aws/scripts/deploy.py
@@ -66,8 +66,25 @@ def find_or_create_service(apprunner, svc_name: str, image_uri: str,
         for svc in resp.get("ServiceSummaryList", []):
             if svc["ServiceName"] == svc_name:
                 arn = svc["ServiceArn"]
-                print(f"  Service exists: {arn}")
-                # Update the service with the new image
+                status = svc.get("Status", "")
+                print(f"  Service exists: {arn} (status: {status})")
+
+                if status == "CREATE_FAILED":
+                    # Delete the failed service and recreate fresh
+                    print(f"  Service is in CREATE_FAILED — deleting before recreating...")
+                    apprunner.delete_service(ServiceArn=arn)
+                    # Poll until deleted
+                    for _ in range(30):
+                        time.sleep(10)
+                        try:
+                            apprunner.describe_service(ServiceArn=arn)
+                        except ClientError as e:
+                            if "ResourceNotFoundException" in str(e) or "does not exist" in str(e).lower():
+                                break
+                    print(f"  Deleted. Creating fresh service...")
+                    break  # fall through to create
+
+                # Update the existing service
                 apprunner.update_service(
                     ServiceArn=arn,
                     SourceConfiguration={
@@ -110,24 +127,54 @@ def find_or_create_service(apprunner, svc_name: str, image_uri: str,
     return arn, "CREATING"
 
 
-def wait_for_running(apprunner, service_arn: str, timeout_s: int = 300) -> str:
-    """Poll until service reaches RUNNING. Returns the service URL."""
-    print(f"  Waiting for service to reach RUNNING state...")
+def get_apprunner_events(apprunner, service_arn: str, max_lines: int = 10) -> list[str]:
+    """Fetch recent App Runner service events for diagnostics."""
+    try:
+        resp = apprunner.list_operations(ServiceArn=service_arn)
+        events = []
+        for op in resp.get("OperationSummaryList", [])[:3]:
+            events.append(f"  [{op.get('Status','?')}] {op.get('Type','?')} @ {op.get('StartedAt','?')}")
+        return events
+    except Exception:
+        return []
+
+
+def wait_for_running(apprunner, service_arn: str, timeout_s: int = 1200) -> str:
+    """Poll until service reaches RUNNING. Returns the service URL.
+
+    First deploys typically take 10-20 minutes on App Runner.
+    Prints recent events log on timeout for diagnostics.
+    """
+    print(f"  Waiting for service to reach RUNNING state (timeout: {timeout_s//60}m)...")
     deadline = time.time() + timeout_s
+    last_status = None
     while time.time() < deadline:
         resp = apprunner.describe_service(ServiceArn=service_arn)
         svc = resp["Service"]
         status = svc["Status"]
         url = svc.get("ServiceUrl", "")
-        print(f"    Status: {status}")
+        if status != last_status:
+            elapsed = int(time.time() - (deadline - timeout_s))
+            print(f"    [{elapsed:3d}s] {status}")
+            last_status = status
         if status == "RUNNING":
             return f"https://{url}"
-        if status in ("CREATE_FAILED", "DELETE_FAILED", "OPERATION_IN_PROGRESS"):
-            if status not in ("OPERATION_IN_PROGRESS",):
-                print(f"ERROR: service entered {status} state", file=sys.stderr)
-                sys.exit(1)
+        if status in ("CREATE_FAILED", "DELETE_FAILED"):
+            print(f"ERROR: service entered {status} state", file=sys.stderr)
+            events = get_apprunner_events(apprunner, service_arn)
+            if events:
+                print("Recent events:", file=sys.stderr)
+                for e in events:
+                    print(e, file=sys.stderr)
+            sys.exit(1)
         time.sleep(10)
-    print(f"ERROR: timed out waiting for service to reach RUNNING after {timeout_s}s", file=sys.stderr)
+
+    print(f"ERROR: timed out after {timeout_s//60}m waiting for RUNNING", file=sys.stderr)
+    events = get_apprunner_events(apprunner, service_arn)
+    if events:
+        print("Recent events:", file=sys.stderr)
+        for e in events:
+            print(e, file=sys.stderr)
     sys.exit(1)
 
 

--- a/skills/deploy-aws/scripts/provision.py
+++ b/skills/deploy-aws/scripts/provision.py
@@ -205,6 +205,44 @@ def ensure_rds_instance(rds, ec2, app: str, existing_password: str | None) -> di
     }
 
 
+# ── DB Migration ─────────────────────────────────────────────────────────────
+
+
+def _run_db_migrate(db_url: str) -> None:
+    """Run prisma db push and db:seed from the repo root using the production DATABASE_URL.
+
+    Uses pnpm workspace filter to target the db package. Seed uses upsert so it's
+    safe to re-run on every deploy — idempotent by design.
+    """
+    import subprocess as sp
+    import os
+
+    env = {**os.environ, "DATABASE_URL": db_url}
+
+    print("\nDatabase migration:")
+    print("  Running db:push...")
+    result = sp.run(
+        ["pnpm", "--filter", "**/db", "db:push", "--accept-data-loss"],
+        env=env, capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        print(f"  WARNING: db:push failed (exit {result.returncode})", file=sys.stderr)
+        print(result.stderr[-500:] if result.stderr else "(no output)", file=sys.stderr)
+    else:
+        print("  db:push: done")
+
+    print("  Running db:seed...")
+    result = sp.run(
+        ["pnpm", "--filter", "**/db", "db:seed"],
+        env=env, capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        print(f"  WARNING: db:seed failed (exit {result.returncode})", file=sys.stderr)
+        print(result.stderr[-500:] if result.stderr else "(no output)", file=sys.stderr)
+    else:
+        print("  db:seed: done")
+
+
 # ── Main ─────────────────────────────────────────────────────────────────────
 
 
@@ -214,6 +252,7 @@ def main():
     parser.add_argument("--region", default="us-east-1")
     parser.add_argument("--services", required=True, help="Comma-separated service names, e.g. api,web")
     parser.add_argument("--db", default="none", help="'rds', 'none', or 'external:<DATABASE_URL>'")
+    parser.add_argument("--skip-migrate", action="store_true", help="Skip db:push and db:seed after RDS provisioning")
     args = parser.parse_args()
 
     services = [s.strip() for s in args.services.split(",")]
@@ -251,7 +290,14 @@ def main():
         existing_password = config.get("database", {}).get("password")
         db_info = ensure_rds_instance(rds, ec2, args.app, existing_password)
         config["database"] = db_info
-        db_url = f"postgresql://{db_info['username']}:{db_info['password']}@{db_info['endpoint']}:{db_info['port']}/{db_info['name']}"
+        # sslmode=no-verify: RDS requires SSL but the Prisma pg adapter doesn't
+        # enable it by default, and sslmode=require triggers full cert verification
+        # (no CA cert in container). no-verify encrypts without cert chain check.
+        db_url = (
+            f"postgresql://{db_info['username']}:{db_info['password']}"
+            f"@{db_info['endpoint']}:{db_info['port']}/{db_info['name']}"
+            f"?sslmode=no-verify"
+        )
         config["database"]["url"] = db_url
     elif args.db.startswith("external:"):
         db_url = args.db[len("external:"):]
@@ -262,6 +308,10 @@ def main():
         config.pop("database", None)
 
     save_config(config)
+
+    # Run db migrations + seed after RDS is up
+    if "database" in config and "url" in config["database"] and not args.skip_migrate:
+        _run_db_migrate(config["database"]["url"])
 
     print("\n── Provision complete ──────────────────────────────")
     for service in services:

--- a/skills/deploy-aws/scripts/provision.py
+++ b/skills/deploy-aws/scripts/provision.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""
+Idempotent AWS infrastructure provisioner for deploy-aws skill.
+Creates ECR repos, IAM role, and optionally RDS instance.
+Saves state to .deploy-aws.json in the current directory.
+"""
+
+import argparse
+import json
+import os
+import random
+import string
+import sys
+import time
+from pathlib import Path
+
+import boto3
+from botocore.exceptions import ClientError
+
+
+def load_config() -> dict:
+    p = Path(".deploy-aws.json")
+    if p.exists():
+        return json.loads(p.read_text())
+    return {}
+
+
+def save_config(config: dict) -> None:
+    Path(".deploy-aws.json").write_text(json.dumps(config, indent=2) + "\n")
+    print("  Saved .deploy-aws.json")
+
+
+def get_account_id(session: boto3.Session) -> str:
+    return session.client("sts").get_caller_identity()["Account"]
+
+
+# ── ECR ──────────────────────────────────────────────────────────────────────
+
+
+def ensure_ecr_repo(ecr, app: str, service: str) -> str:
+    """Create ECR repo if it doesn't exist. Returns the repo URI."""
+    name = f"{app}-{service}"
+    try:
+        resp = ecr.describe_repositories(repositoryNames=[name])
+        uri = resp["repositories"][0]["repositoryUri"]
+        print(f"  ECR repo already exists: {uri}")
+        return uri
+    except ClientError as e:
+        if e.response["Error"]["Code"] != "RepositoryNotFoundException":
+            raise
+    resp = ecr.create_repository(
+        repositoryName=name,
+        imageScanningConfiguration={"scanOnPush": True},
+        imageTagMutability="MUTABLE",
+    )
+    uri = resp["repository"]["repositoryUri"]
+    print(f"  Created ECR repo: {uri}")
+    return uri
+
+
+# ── IAM ──────────────────────────────────────────────────────────────────────
+
+APPRUNNER_TRUST_POLICY = json.dumps({
+    "Version": "2012-10-17",
+    "Statement": [{
+        "Effect": "Allow",
+        "Principal": {"Service": "build.apprunner.amazonaws.com"},
+        "Action": "sts:AssumeRole",
+    }],
+})
+
+ECR_ACCESS_POLICY_ARN = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+
+
+def ensure_apprunner_role(iam, app: str) -> str:
+    """Create App Runner ECR access role if it doesn't exist. Returns the role ARN."""
+    role_name = f"{app}-apprunner-ecr-role"
+    try:
+        resp = iam.get_role(RoleName=role_name)
+        arn = resp["Role"]["Arn"]
+        print(f"  IAM role already exists: {arn}")
+        return arn
+    except ClientError as e:
+        if e.response["Error"]["Code"] != "NoSuchEntity":
+            raise
+    resp = iam.create_role(
+        RoleName=role_name,
+        AssumeRolePolicyDocument=APPRUNNER_TRUST_POLICY,
+        Description=f"App Runner ECR pull role for {app}",
+    )
+    iam.attach_role_policy(RoleName=role_name, PolicyArn=ECR_ACCESS_POLICY_ARN)
+    arn = resp["Role"]["Arn"]
+    print(f"  Created IAM role: {arn}")
+    # IAM propagation delay
+    time.sleep(10)
+    return arn
+
+
+# ── RDS ──────────────────────────────────────────────────────────────────────
+
+
+def gen_password(length: int = 24) -> str:
+    chars = string.ascii_letters + string.digits
+    return "".join(random.SystemRandom().choice(chars) for _ in range(length))
+
+
+def ensure_rds_security_group(ec2, app: str) -> str:
+    """Create a security group that allows Postgres from anywhere (App Runner uses NAT IPs).
+    Returns the SG id."""
+    sg_name = f"{app}-rds-sg"
+    sgs = ec2.describe_security_groups(
+        Filters=[{"Name": "group-name", "Values": [sg_name]}]
+    )["SecurityGroups"]
+    if sgs:
+        sg_id = sgs[0]["GroupId"]
+        print(f"  Security group already exists: {sg_id}")
+        return sg_id
+    sg = ec2.create_security_group(
+        GroupName=sg_name,
+        Description=f"RDS access for {app} App Runner services",
+    )
+    sg_id = sg["GroupId"]
+    ec2.authorize_security_group_ingress(
+        GroupId=sg_id,
+        IpPermissions=[{
+            "IpProtocol": "tcp",
+            "FromPort": 5432,
+            "ToPort": 5432,
+            "IpRanges": [{"CidrIp": "0.0.0.0/0", "Description": "App Runner egress IPs (dynamic)"}],
+        }],
+    )
+    print(f"  Created security group: {sg_id}")
+    return sg_id
+
+
+def ensure_rds_instance(rds, ec2, app: str, existing_password: str | None) -> dict:
+    """Create free-tier RDS Postgres instance. Returns db info dict."""
+    identifier = f"{app}-db"
+    db_name = app.replace("-", "_")
+    password = existing_password or gen_password()
+
+    try:
+        resp = rds.describe_db_instances(DBInstanceIdentifier=identifier)
+        db = resp["DBInstances"][0]
+        endpoint = db.get("Endpoint", {})
+        if endpoint:
+            host = endpoint["Address"]
+            port = endpoint["Port"]
+            print(f"  RDS instance already exists: {host}:{port}")
+            return {
+                "identifier": identifier,
+                "endpoint": host,
+                "port": port,
+                "name": db_name,
+                "username": "postgres",
+                "password": password,  # may differ from actual if not first run
+            }
+        else:
+            print(f"  RDS instance exists but not yet available, waiting...")
+    except ClientError as e:
+        if e.response["Error"]["Code"] != "DBInstanceNotFound":
+            raise
+
+    sg_id = ensure_rds_security_group(ec2, app)
+
+    rds.create_db_instance(
+        DBInstanceIdentifier=identifier,
+        DBName=db_name,
+        DBInstanceClass="db.t3.micro",
+        Engine="postgres",
+        EngineVersion="16",
+        MasterUsername="postgres",
+        MasterUserPassword=password,
+        AllocatedStorage=20,
+        StorageType="gp2",
+        PubliclyAccessible=True,
+        VpcSecurityGroupIds=[sg_id],
+        BackupRetentionPeriod=1,
+        MultiAZ=False,
+        Tags=[{"Key": "app", "Value": app}],
+    )
+    print(f"  Created RDS instance {identifier} (free tier: db.t3.micro, 20GB)")
+    print("  Waiting for RDS to become available (this takes 3-5 minutes)...")
+
+    waiter = rds.get_waiter("db_instance_available")
+    waiter.wait(
+        DBInstanceIdentifier=identifier,
+        WaiterConfig={"Delay": 15, "MaxAttempts": 40},
+    )
+
+    resp = rds.describe_db_instances(DBInstanceIdentifier=identifier)
+    db = resp["DBInstances"][0]
+    endpoint = db["Endpoint"]
+    host = endpoint["Address"]
+    port = endpoint["Port"]
+    print(f"  RDS ready: {host}:{port}")
+
+    return {
+        "identifier": identifier,
+        "endpoint": host,
+        "port": port,
+        "name": db_name,
+        "username": "postgres",
+        "password": password,
+    }
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Provision AWS infra for deployment")
+    parser.add_argument("--app", required=True, help="App name (used for resource naming)")
+    parser.add_argument("--region", default="us-east-1")
+    parser.add_argument("--services", required=True, help="Comma-separated service names, e.g. api,web")
+    parser.add_argument("--db", default="none", help="'rds', 'none', or 'external:<DATABASE_URL>'")
+    args = parser.parse_args()
+
+    services = [s.strip() for s in args.services.split(",")]
+    session = boto3.Session(region_name=args.region)
+    account_id = get_account_id(session)
+
+    config = load_config()
+    config.setdefault("app", args.app)
+    config.setdefault("region", args.region)
+    config["account"] = account_id
+    config.setdefault("services", {})
+
+    print(f"\nProvisioning infrastructure for '{args.app}' in {args.region}")
+    print(f"Account: {account_id}\n")
+
+    # ECR repos
+    ecr = session.client("ecr")
+    print("ECR repositories:")
+    for service in services:
+        uri = ensure_ecr_repo(ecr, args.app, service)
+        config["services"].setdefault(service, {})
+        config["services"][service]["ecr_repo"] = uri
+
+    # IAM role
+    print("\nIAM role:")
+    iam = session.client("iam")
+    role_arn = ensure_apprunner_role(iam, args.app)
+    config["iam_role_arn"] = role_arn
+
+    # Database
+    if args.db == "rds":
+        print("\nRDS Postgres:")
+        rds = session.client("rds")
+        ec2 = session.client("ec2")
+        existing_password = config.get("database", {}).get("password")
+        db_info = ensure_rds_instance(rds, ec2, args.app, existing_password)
+        config["database"] = db_info
+        db_url = f"postgresql://{db_info['username']}:{db_info['password']}@{db_info['endpoint']}:{db_info['port']}/{db_info['name']}"
+        config["database"]["url"] = db_url
+    elif args.db.startswith("external:"):
+        db_url = args.db[len("external:"):]
+        config["database"] = {"url": db_url, "source": "external"}
+        print(f"\nDatabase: using external URL")
+    else:
+        print("\nDatabase: none")
+        config.pop("database", None)
+
+    save_config(config)
+
+    print("\n── Provision complete ──────────────────────────────")
+    for service in services:
+        print(f"  {service}: {config['services'][service]['ecr_repo']}")
+    if "database" in config and "endpoint" in config["database"]:
+        db = config["database"]
+        print(f"  db: {db['endpoint']}:{db['port']}/{db['name']}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/deploy-aws/scripts/provision.py
+++ b/skills/deploy-aws/scripts/provision.py
@@ -60,14 +60,18 @@ def ensure_ecr_repo(ecr, app: str, service: str) -> str:
 
 # ── IAM ──────────────────────────────────────────────────────────────────────
 
-APPRUNNER_TRUST_POLICY = json.dumps({
-    "Version": "2012-10-17",
-    "Statement": [{
-        "Effect": "Allow",
-        "Principal": {"Service": "build.apprunner.amazonaws.com"},
-        "Action": "sts:AssumeRole",
-    }],
-})
+APPRUNNER_TRUST_POLICY = json.dumps(
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"Service": "build.apprunner.amazonaws.com"},
+                "Action": "sts:AssumeRole",
+            }
+        ],
+    }
+)
 
 ECR_ACCESS_POLICY_ARN = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
 
@@ -108,9 +112,9 @@ def ensure_rds_security_group(ec2, app: str) -> str:
     """Create a security group that allows Postgres from anywhere (App Runner uses NAT IPs).
     Returns the SG id."""
     sg_name = f"{app}-rds-sg"
-    sgs = ec2.describe_security_groups(
-        Filters=[{"Name": "group-name", "Values": [sg_name]}]
-    )["SecurityGroups"]
+    sgs = ec2.describe_security_groups(Filters=[{"Name": "group-name", "Values": [sg_name]}])[
+        "SecurityGroups"
+    ]
     if sgs:
         sg_id = sgs[0]["GroupId"]
         print(f"  Security group already exists: {sg_id}")
@@ -122,12 +126,16 @@ def ensure_rds_security_group(ec2, app: str) -> str:
     sg_id = sg["GroupId"]
     ec2.authorize_security_group_ingress(
         GroupId=sg_id,
-        IpPermissions=[{
-            "IpProtocol": "tcp",
-            "FromPort": 5432,
-            "ToPort": 5432,
-            "IpRanges": [{"CidrIp": "0.0.0.0/0", "Description": "App Runner egress IPs (dynamic)"}],
-        }],
+        IpPermissions=[
+            {
+                "IpProtocol": "tcp",
+                "FromPort": 5432,
+                "ToPort": 5432,
+                "IpRanges": [
+                    {"CidrIp": "0.0.0.0/0", "Description": "App Runner egress IPs (dynamic)"}
+                ],
+            }
+        ],
     )
     print(f"  Created security group: {sg_id}")
     return sg_id
@@ -156,7 +164,7 @@ def ensure_rds_instance(rds, ec2, app: str, existing_password: str | None) -> di
                 "password": password,  # may differ from actual if not first run
             }
         else:
-            print(f"  RDS instance exists but not yet available, waiting...")
+            print("  RDS instance exists but not yet available, waiting...")
     except ClientError as e:
         if e.response["Error"]["Code"] != "DBInstanceNotFound":
             raise
@@ -215,7 +223,6 @@ def _run_db_migrate(db_url: str) -> None:
     safe to re-run on every deploy — idempotent by design.
     """
     import subprocess as sp
-    import os
 
     env = {**os.environ, "DATABASE_URL": db_url}
 
@@ -223,7 +230,9 @@ def _run_db_migrate(db_url: str) -> None:
     print("  Running db:push...")
     result = sp.run(
         ["pnpm", "--filter", "**/db", "db:push", "--accept-data-loss"],
-        env=env, capture_output=True, text=True
+        env=env,
+        capture_output=True,
+        text=True,
     )
     if result.returncode != 0:
         print(f"  WARNING: db:push failed (exit {result.returncode})", file=sys.stderr)
@@ -233,8 +242,7 @@ def _run_db_migrate(db_url: str) -> None:
 
     print("  Running db:seed...")
     result = sp.run(
-        ["pnpm", "--filter", "**/db", "db:seed"],
-        env=env, capture_output=True, text=True
+        ["pnpm", "--filter", "**/db", "db:seed"], env=env, capture_output=True, text=True
     )
     if result.returncode != 0:
         print(f"  WARNING: db:seed failed (exit {result.returncode})", file=sys.stderr)
@@ -250,9 +258,15 @@ def main():
     parser = argparse.ArgumentParser(description="Provision AWS infra for deployment")
     parser.add_argument("--app", required=True, help="App name (used for resource naming)")
     parser.add_argument("--region", default="us-east-1")
-    parser.add_argument("--services", required=True, help="Comma-separated service names, e.g. api,web")
+    parser.add_argument(
+        "--services", required=True, help="Comma-separated service names, e.g. api,web"
+    )
     parser.add_argument("--db", default="none", help="'rds', 'none', or 'external:<DATABASE_URL>'")
-    parser.add_argument("--skip-migrate", action="store_true", help="Skip db:push and db:seed after RDS provisioning")
+    parser.add_argument(
+        "--skip-migrate",
+        action="store_true",
+        help="Skip db:push and db:seed after RDS provisioning",
+    )
     args = parser.parse_args()
 
     services = [s.strip() for s in args.services.split(",")]
@@ -300,9 +314,9 @@ def main():
         )
         config["database"]["url"] = db_url
     elif args.db.startswith("external:"):
-        db_url = args.db[len("external:"):]
+        db_url = args.db[len("external:") :]
         config["database"] = {"url": db_url, "source": "external"}
-        print(f"\nDatabase: using external URL")
+        print("\nDatabase: using external URL")
     else:
         print("\nDatabase: none")
         config.pop("database", None)

--- a/skills/deploy-aws/uv.lock
+++ b/skills/deploy-aws/uv.lock
@@ -33,6 +33,7 @@ dependencies = [
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/31/9d/a9a7b5a9351e3ff0baae01136f71ba6fc4652fe0dc2da3b0a8ebdfc1be44/boto3-1.42.85.tar.gz", hash = "sha256:1cd3dcbfaba85c6071ba9397c1804b6a94a1a97031b8f1993fdba27c0c5d6eba", size = 112769, upload-time = "2026-04-07T19:40:53.834Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/ab/3167b8ec3cf1d87ad08d2ad5f15823a22945cae7870798274c283c3a18f1/boto3-1.42.85-py3-none-any.whl", hash = "sha256:4f6ac066e41d18ec33f532253fac0f35e0fdca373724458f983ce3d531340b7a", size = 140556, upload-time = "2026-04-07T19:40:52.186Z" },
 ]
@@ -63,16 +64,65 @@ source = { virtual = "." }
 dependencies = [
     { name = "boto3" },
     { name = "botocore", extra = ["crt"] },
+    { name = "playwright" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "boto3", specifier = "~=1.42" },
     { name = "botocore", extras = ["crt"], specifier = "~=1.42" },
+    { name = "playwright", specifier = "~=1.49" },
 ]
 
 [package.metadata.requires-dev]
 dev = []
+
+[[package]]
+name = "greenlet"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/94/a5935717b307d7c71fe877b52b884c6af707d2d2090db118a03fbd799369/greenlet-3.4.0.tar.gz", hash = "sha256:f50a96b64dafd6169e595a5c56c9146ef80333e67d4476a65a9c55f400fc22ff", size = 195913, upload-time = "2026-04-08T17:08:00.863Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/8b/3669ad3b3f247a791b2b4aceb3aa5a31f5f6817bf547e4e1ff712338145a/greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a", size = 286902, upload-time = "2026-04-08T15:52:12.138Z" },
+    { url = "https://files.pythonhosted.org/packages/38/3e/3c0e19b82900873e2d8469b590a6c4b3dfd2b316d0591f1c26b38a4879a5/greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97", size = 606099, upload-time = "2026-04-08T16:24:38.408Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/33/99fef65e7754fc76a4ed14794074c38c9ed3394a5bd129d7f61b705f3168/greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996", size = 618837, upload-time = "2026-04-08T16:30:58.298Z" },
+    { url = "https://files.pythonhosted.org/packages/44/57/eae2cac10421feae6c0987e3dc106c6d86262b1cb379e171b017aba893a6/greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d", size = 624901, upload-time = "2026-04-08T16:40:38.981Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc", size = 615062, upload-time = "2026-04-08T15:56:33.766Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/8a/0e73c9b94f31d1cc257fe79a0eff621674141cdae7d6d00f40de378a1e42/greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077", size = 423927, upload-time = "2026-04-08T16:43:05.293Z" },
+    { url = "https://files.pythonhosted.org/packages/08/97/d988180011aa40135c46cd0d0cf01dd97f7162bae14139b4a3ef54889ba5/greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de", size = 1573511, upload-time = "2026-04-08T16:26:20.058Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/0f/a5a26fe152fb3d12e6a474181f6e9848283504d0afd095f353d85726374b/greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08", size = 1640396, upload-time = "2026-04-08T15:57:30.88Z" },
+    { url = "https://files.pythonhosted.org/packages/42/cf/bb2c32d9a100e36ee9f6e38fad6b1e082b8184010cb06259b49e1266ca01/greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2", size = 238892, upload-time = "2026-04-08T17:03:10.094Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/47/6c41314bac56e71436ce551c7fbe3cc830ed857e6aa9708dbb9c65142eb6/greenlet-3.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:f38b81880ba28f232f1f675893a39cf7b6db25b31cc0a09bb50787ecf957e85e", size = 235599, upload-time = "2026-04-08T15:52:54.3Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/75/7e9cd1126a1e1f0cd67b0eda02e5221b28488d352684704a78ed505bd719/greenlet-3.4.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43748988b097f9c6f09364f260741aa73c80747f63389824435c7a50bfdfd5c1", size = 285856, upload-time = "2026-04-08T15:52:45.82Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/c4/3e2df392e5cb199527c4d9dbcaa75c14edcc394b45040f0189f649631e3c/greenlet-3.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5566e4e2cd7a880e8c27618e3eab20f3494452d12fd5129edef7b2f7aa9a36d1", size = 610208, upload-time = "2026-04-08T16:24:39.674Z" },
+    { url = "https://files.pythonhosted.org/packages/da/af/750cdfda1d1bd30a6c28080245be8d0346e669a98fdbae7f4102aa95fff3/greenlet-3.4.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82", size = 621269, upload-time = "2026-04-08T16:30:59.767Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/93/c8c508d68ba93232784bbc1b5474d92371f2897dfc6bc281b419f2e0d492/greenlet-3.4.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:98eedd1803353daf1cd9ef23eef23eda5a4d22f99b1f998d273a8b78b70dd47f", size = 628455, upload-time = "2026-04-08T16:40:40.698Z" },
+    { url = "https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf", size = 617549, upload-time = "2026-04-08T15:56:34.893Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/46/cfaaa0ade435a60550fd83d07dfd5c41f873a01da17ede5c4cade0b9bab8/greenlet-3.4.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:b7857e2202aae67bc5725e0c1f6403c20a8ff46094ece015e7d474f5f7020b55", size = 426238, upload-time = "2026-04-08T16:43:06.865Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c0/8966767de01343c1ff47e8b855dc78e7d1a8ed2b7b9c83576a57e289f81d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:227a46251ecba4ff46ae742bc5ce95c91d5aceb4b02f885487aff269c127a729", size = 1575310, upload-time = "2026-04-08T16:26:21.671Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/38/bcdc71ba05e9a5fda87f63ffc2abcd1f15693b659346df994a48c968003d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c", size = 1640435, upload-time = "2026-04-08T15:57:32.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/c2/19b664b7173b9e4ef5f77e8cef9f14c20ec7fce7920dc1ccd7afd955d093/greenlet-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940", size = 238760, upload-time = "2026-04-08T17:04:03.878Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/96/795619651d39c7fbd809a522f881aa6f0ead504cc8201c3a5b789dfaef99/greenlet-3.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:9390ad88b652b1903814eaabd629ca184db15e0eeb6fe8a390bbf8b9106ae15a", size = 235498, upload-time = "2026-04-08T17:05:00.584Z" },
+    { url = "https://files.pythonhosted.org/packages/78/02/bde66806e8f169cf90b14d02c500c44cdbe02c8e224c9c67bafd1b8cadd1/greenlet-3.4.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e", size = 286291, upload-time = "2026-04-08T17:09:34.307Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1f/39da1c336a87d47c58352fb8a78541ce63d63ae57c5b9dae1fe02801bbc2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d", size = 656749, upload-time = "2026-04-08T16:24:41.721Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/6c/90ee29a4ee27af7aa2e2ec408799eeb69ee3fcc5abcecac6ddd07a5cd0f2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615", size = 669084, upload-time = "2026-04-08T16:31:01.372Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/4a/74078d3936712cff6d3c91a930016f476ce4198d84e224fe6d81d3e02880/greenlet-3.4.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:06c2d3b89e0c62ba50bd7adf491b14f39da9e7e701647cb7b9ff4c99bee04b19", size = 673405, upload-time = "2026-04-08T16:40:42.527Z" },
+    { url = "https://files.pythonhosted.org/packages/07/49/d4cad6e5381a50947bb973d2f6cf6592621451b09368b8c20d9b8af49c5b/greenlet-3.4.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf", size = 665621, upload-time = "2026-04-08T15:56:35.995Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3e/df8a83ab894751bc31e1106fdfaa80ca9753222f106b04de93faaa55feb7/greenlet-3.4.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:070b8bac2ff3b4d9e0ff36a0d19e42103331d9737e8504747cd1e659f76297bd", size = 471670, upload-time = "2026-04-08T16:43:08.512Z" },
+    { url = "https://files.pythonhosted.org/packages/37/31/d1edd54f424761b5d47718822f506b435b6aab2f3f93b465441143ea5119/greenlet-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf", size = 1622259, upload-time = "2026-04-08T16:26:23.201Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c6/6d3f9cdcb21c4e12a79cb332579f1c6aa1af78eb68059c5a957c7812d95e/greenlet-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda", size = 1686916, upload-time = "2026-04-08T15:57:34.282Z" },
+    { url = "https://files.pythonhosted.org/packages/63/45/c1ca4a1ad975de4727e52d3ffe641ae23e1d7a8ffaa8ff7a0477e1827b92/greenlet-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d", size = 239821, upload-time = "2026-04-08T17:03:48.423Z" },
+    { url = "https://files.pythonhosted.org/packages/71/c4/6f621023364d7e85a4769c014c8982f98053246d142420e0328980933ceb/greenlet-3.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:f8296d4e2b92af34ebde81085a01690f26a51eb9ac09a0fcadb331eb36dbc802", size = 236932, upload-time = "2026-04-08T17:04:33.551Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8f/18d72b629783f5e8d045a76f5325c1e938e659a9e4da79c7dcd10169a48d/greenlet-3.4.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece", size = 294681, upload-time = "2026-04-08T15:52:35.778Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ad/5fa86ec46769c4153820d58a04062285b3b9e10ba3d461ee257b68dcbf53/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8", size = 658899, upload-time = "2026-04-08T16:24:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f0/4e8174ca0e87ae748c409f055a1ba161038c43cc0a5a6f1433a26ac2e5bf/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2", size = 665284, upload-time = "2026-04-08T16:31:02.833Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/92/466b0d9afd44b8af623139a3599d651c7564fa4152f25f117e1ee5949ffb/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4cd56a9eb7a6444edbc19062f7b6fbc8f287c663b946e3171d899693b1c19fa", size = 665872, upload-time = "2026-04-08T16:40:43.912Z" },
+    { url = "https://files.pythonhosted.org/packages/19/da/991cf7cd33662e2df92a1274b7eb4d61769294d38a1bba8a45f31364845e/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed", size = 661861, upload-time = "2026-04-08T15:56:37.269Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/14/3395a7ef3e260de0325152ddfe19dffb3e49fe10873b94654352b53ad48e/greenlet-3.4.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:1f85f204c4d54134ae850d401fa435c89cd667d5ce9dc567571776b45941af72", size = 489237, upload-time = "2026-04-08T16:43:09.993Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
+    { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
+]
 
 [[package]]
 name = "jmespath"
@@ -81,6 +131,37 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "playwright"
+version = "1.58.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/c9/9c6061d5703267f1baae6a4647bfd1862e386fbfdb97d889f6f6ae9e3f64/playwright-1.58.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:96e3204aac292ee639edbfdef6298b4be2ea0a55a16b7068df91adac077cc606", size = 42251098, upload-time = "2026-01-30T15:09:24.028Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/40/59d34a756e02f8c670f0fee987d46f7ee53d05447d43cd114ca015cb168c/playwright-1.58.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:70c763694739d28df71ed578b9c8202bb83e8fe8fb9268c04dd13afe36301f71", size = 41039625, upload-time = "2026-01-30T15:09:27.558Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ee/3ce6209c9c74a650aac9028c621f357a34ea5cd4d950700f8e2c4b7fe2c4/playwright-1.58.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:185e0132578733d02802dfddfbbc35f42be23a45ff49ccae5081f25952238117", size = 42251098, upload-time = "2026-01-30T15:09:30.461Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/af/009958cbf23fac551a940d34e3206e6c7eed2b8c940d0c3afd1feb0b0589/playwright-1.58.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c95568ba1eda83812598c1dc9be60b4406dffd60b149bc1536180ad108723d6b", size = 46235268, upload-time = "2026-01-30T15:09:33.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a6/0e66ad04b6d3440dae73efb39540c5685c5fc95b17c8b29340b62abbd952/playwright-1.58.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f9999948f1ab541d98812de25e3a8c410776aa516d948807140aff797b4bffa", size = 45964214, upload-time = "2026-01-30T15:09:36.751Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/236e60ab9f6d62ed0fd32150d61f1f494cefbf02304c0061e78ed80c1c32/playwright-1.58.0-py3-none-win32.whl", hash = "sha256:1e03be090e75a0fabbdaeab65ce17c308c425d879fa48bb1d7986f96bfad0b99", size = 36815998, upload-time = "2026-01-30T15:09:39.627Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f8/5ec599c5e59d2f2f336a05b4f318e733077cd5044f24adb6f86900c3e6a7/playwright-1.58.0-py3-none-win_amd64.whl", hash = "sha256:a2bf639d0ce33b3ba38de777e08697b0d8f3dc07ab6802e4ac53fb65e3907af8", size = 36816005, upload-time = "2026-01-30T15:09:42.449Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c4/cc0229fea55c87d6c9c67fe44a21e2cd28d1d558a5478ed4d617e9fb0c93/playwright-1.58.0-py3-none-win_arm64.whl", hash = "sha256:32ffe5c303901a13a0ecab91d1c3f74baf73b84f4bedbb6b935f5bc11cc98e1b", size = 33085919, upload-time = "2026-01-30T15:09:45.71Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]
@@ -114,6 +195,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]

--- a/skills/deploy-aws/uv.lock
+++ b/skills/deploy-aws/uv.lock
@@ -1,0 +1,126 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "awscrt"
+version = "0.31.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/05/1697c67ad80be475d5deb8961182d10b4a93d29f1cf9f6fdea169bda88c3/awscrt-0.31.2.tar.gz", hash = "sha256:552555de1beff02d72a1f6d384cd49c5a7c283418310eae29d21bcb749c65792", size = 38169245, upload-time = "2026-02-13T10:27:06.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/8a/c5f8b1a4a3dc37b6b1a2a663887ac2fe67b1e6c877f50e68aa0ac86b74be/awscrt-0.31.2-cp311-abi3-macosx_10_15_universal2.whl", hash = "sha256:49c003d7fe40002dc4e26500f6cc63c61b399d44b4e38e66b5065845d296d230", size = 3457136, upload-time = "2026-02-13T10:26:20.412Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/bde40ce3ae7d5d08030ac59442b6121ce8b078651dfec87756ff9f7a4d4e/awscrt-0.31.2-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ac9d662de99c2f1393011cde357d0c8730aef9df4eedf258505bdf6ff20a3c01", size = 3888743, upload-time = "2026-02-13T10:26:21.563Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/88/f4251a2028f0cafee9806060a8538e6b4909bb5136584ba4d219c6d5bf04/awscrt-0.31.2-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8387e72f856b7a92f7d08ff9a1dfa6960d6e9ed39509c63c5905e240071af23e", size = 4175553, upload-time = "2026-02-13T10:26:22.993Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e4/9aaaaed4016ec142cac0ff01f6a8f5c9bed0c5d3d2dfcc3a269e66dca6e6/awscrt-0.31.2-cp311-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:43b3f774afd5dc2471d38490a16ed3e789814f120b9552c76920cb2fb812376f", size = 3792457, upload-time = "2026-02-13T10:26:24.328Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/94/3d8e8732854d7cf9a6468e3074c3d2151cea95699fa10cdda7df86d4e4e4/awscrt-0.31.2-cp311-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:10d5541726b87246fbfeb4c70036373b7aba8b40f489e5ae886eabc09a68ef38", size = 4031362, upload-time = "2026-02-13T10:26:25.763Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/21/0d09bc1d1c193026322352f445271ae3f60ca62d8f048d6f07a000a1d869/awscrt-0.31.2-cp311-abi3-win32.whl", hash = "sha256:14e28cabf7857cfe6d82548821410c688e772a819dbf15d167359d7bc54cdb8d", size = 4027275, upload-time = "2026-02-13T10:26:27.248Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/d4/94075b06d37b80727738afd24548ac2a20ca6980822a3ce1265850e00b53/awscrt-0.31.2-cp311-abi3-win_amd64.whl", hash = "sha256:ebd98aaaf348334f72d3a38aed18c29b808fe978c295e7c6bc2e21deac5126c8", size = 4177352, upload-time = "2026-02-13T10:26:28.529Z" },
+    { url = "https://files.pythonhosted.org/packages/95/eb/9ce53bd498050049ef88e9d074fac6bbe19301ba9593d6f7a834a2321a68/awscrt-0.31.2-cp313-abi3-macosx_10_15_universal2.whl", hash = "sha256:3eb623d0abfbbe5e6666b9c39780737b472766b0e01168296b048a27ef9d13e8", size = 3455722, upload-time = "2026-02-13T10:26:29.818Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/88/c9ceaa77cd0384c6f50cc1854fcf5dc0b1aa364349aeb18e1c2d1d6ffdd2/awscrt-0.31.2-cp313-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03de99bd3077e1b3bbcd1eca9d06a735fdb8fd47b2af8b1d464d43ede00f125a", size = 3880501, upload-time = "2026-02-13T10:26:30.983Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ca/27858b8de6a1bbb4e4df035a272b6e80d214b83bc6d6998b286df82be1b5/awscrt-0.31.2-cp313-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1a4adc5ff6eae8a46f5bca4ed70ad68d36f1e272e2fcd60afeef71b4d02afe06", size = 4170259, upload-time = "2026-02-13T10:26:32.261Z" },
+    { url = "https://files.pythonhosted.org/packages/da/25/c0668247ac856ab6d033b7ac7ee3f4f32b6628a7900542b303eede4685e0/awscrt-0.31.2-cp313-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:83d45c3ee9e1fe10c2d316b93402157199edb5d20b1584facf24f82981b55190", size = 3783744, upload-time = "2026-02-13T10:26:33.523Z" },
+    { url = "https://files.pythonhosted.org/packages/91/52/3ac02206875947a7ed388ba176e7194f77a9a03430333584e63c8011d0c9/awscrt-0.31.2-cp313-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:a1d1f3e07cdd926bbc9a3715826e5794217780e7a326c329bdbf453533d2141a", size = 4026326, upload-time = "2026-02-13T10:26:34.799Z" },
+    { url = "https://files.pythonhosted.org/packages/80/16/6256dd1f1bb4172dde19d0b3e35f1fc4eec9c296f214246a7a6628ed03b4/awscrt-0.31.2-cp313-abi3-win32.whl", hash = "sha256:cf02b5db1181811f5e7c70e772986ef4a6577f722a6b3222842ae377df41d261", size = 4021950, upload-time = "2026-02-13T10:26:36.067Z" },
+    { url = "https://files.pythonhosted.org/packages/62/cf/14a9357d992338cd05a6389c9f6c51a5fc1e1c5e421fe061bf528f15374c/awscrt-0.31.2-cp313-abi3-win_amd64.whl", hash = "sha256:4b459be11d9aba47d3cb37e10e97702eed2a2858aa381e2586f7f73d15d85bdf", size = 4172066, upload-time = "2026-02-13T10:26:37.436Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.42.85"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/ab/3167b8ec3cf1d87ad08d2ad5f15823a22945cae7870798274c283c3a18f1/boto3-1.42.85-py3-none-any.whl", hash = "sha256:4f6ac066e41d18ec33f532253fac0f35e0fdca373724458f983ce3d531340b7a", size = 140556, upload-time = "2026-04-07T19:40:52.186Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.85"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/ac/7f14b05cf43e4baae99f4570b02e10b2aebf242dfd86245523340390c834/botocore-1.42.85.tar.gz", hash = "sha256:2ee61f80b7724a143e16d0a85408ef5fa20b99dce7a3c8ec5d25cc8dced164c1", size = 15159562, upload-time = "2026-04-07T19:40:43.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/f3/c1fbaff4c509c616fd01f44357283a8992f10b3a05d932b22e602aa3a221/botocore-1.42.85-py3-none-any.whl", hash = "sha256:828b67722caeb7e240eefedee74050e803d1fa102958ead9c4009101eefd5381", size = 14839741, upload-time = "2026-04-07T19:40:40.733Z" },
+]
+
+[package.optional-dependencies]
+crt = [
+    { name = "awscrt" },
+]
+
+[[package]]
+name = "deploy-aws"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore", extra = ["crt"] },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "boto3", specifier = "~=1.42" },
+    { name = "botocore", extras = ["crt"], specifier = "~=1.42" },
+]
+
+[package.metadata.requires-dev]
+dev = []
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]

--- a/skills/solve-take-home/SKILL.md
+++ b/skills/solve-take-home/SKILL.md
@@ -14,6 +14,7 @@ You are a senior engineer solving a coding take-home challenge. Your job is to c
 **Pre-loaded context:**
 - Current branch: !`~/.claude/skills/shared/scripts/context.sh current-branch`
 - CWD contents: !`ls -la 2>/dev/null | head -20`
+- Available templates: !`~/.claude/skills/create-repo/scripts/context.sh list-templates`
 
 ---
 
@@ -127,12 +128,23 @@ If the repo has a package.json, pyproject.toml, or equivalent project config —
 ### Empty or instructions-only
 If the repo is empty or contains only instruction files (README, PDFs, etc.):
 
-Run `/create-repo` with the appropriate template. Pick the template based on:
+Pick the template based on:
 - Stack constraints from the instructions (if they say "use React + Express", match the closest template)
 - If no stack prescribed, recommend based on the challenge type and ask the user
 
+Available templates are listed in the pre-loaded context above. Pick the best fit for the challenge stack.
+
+Derive a project name from the challenge title (lowercase-hyphenated). Then run:
+```
+/create-repo <template> <project-name>
+```
+Passing both arguments skips the interactive interview entirely. create-repo handles everything: dependencies, Docker, database, git init, and GitHub repo creation.
+
 ### Starting from text with no repo
-Run `/create-repo` to scaffold from scratch, including git init and GitHub repo creation.
+Derive a project name from the challenge description, pick the best template, then run:
+```
+/create-repo <template> <project-name>
+```
 
 After scaffolding (or skipping), confirm: **"Project structure is ready. Moving to planning."**
 
@@ -219,11 +231,19 @@ Run `/hack full auto` to execute the plan end-to-end.
 ### When building on a `/create-repo` scaffold
 
 The scaffold includes sample content that may be useful or need cleanup:
-- A **User model**, `user.list`/`user.create` routes, and seed data are included as working examples
+- A **User model**, sample routes, and seed data are included as working examples
 - If users are relevant to the challenge: extend the existing User model and routes
-- If users are irrelevant: run `pnpm cleanup-samples` first to strip sample content cleanly
-- Always build on the existing router structure in `apps/api/src/router.ts`
-- Extend `prisma/seed.ts` for challenge-specific test data rather than creating a separate seeding mechanism
+- If users are irrelevant: strip sample content first
+
+**TypeScript templates** (`fullstack-ts`, `fullstack-graphql`, `api-ts`):
+- Run `pnpm cleanup-samples` to strip sample content cleanly
+- Build on the existing router structure in `apps/api/src/router.ts`
+- Extend `packages/db/prisma/seed.ts` for challenge-specific test data
+
+**Python templates** (`api-python`, `fullstack-python`):
+- No cleanup script — manually remove `apps/api/src/routes/users.py` and the corresponding import/include in `apps/api/src/main.py`
+- Add new routes as files in `apps/api/src/routes/` and register them in `main.py`
+- Define models in `apps/api/src/models.py` (SQLModel for DB models, Pydantic for request/response)
 
 ### Take-home-specific guidance
 

--- a/skills/sync-guidance/SKILL.md
+++ b/skills/sync-guidance/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: sync-guidance
+description: Sync Claude guidance between machines. Reads ~/.claude/CLAUDE.md on the current machine, diffs it against this repo's rules, and does two things — (1) updates the personal (unfenced) section of CLAUDE.md with anything new from the repo, and (2) proposes a PR to the repo with any novel guidance found on this machine. Run this on a work machine after cloning the repo to stay in sync.
+argument-hint: "[inbound|outbound|both]"
+---
+
+# Sync Guidance
+
+You are syncing Claude guidance between this machine's `~/.claude/CLAUDE.md` and the agent-skills repo. The goal is to keep personal guidance in sync across machines without touching anything managed by others.
+
+**Arguments:** $ARGUMENTS
+- `inbound` — only update `~/.claude/CLAUDE.md` from repo (repo → this machine)
+- `outbound` — only propose PR with novel guidance from this machine (this machine → repo)
+- `both` (default) — do both directions
+
+**Pre-loaded context:**
+
+- CLAUDE.md contents and fence map: !`~/.claude/skills/sync-guidance/scripts/context.sh claude-md`
+- Repo rules and shared template: !`~/.claude/skills/sync-guidance/scripts/context.sh repo-rules`
+- Repo git status: !`~/.claude/skills/sync-guidance/scripts/context.sh git-status`
+
+---
+
+## Step 0: Understand the Landscape
+
+From the pre-loaded context, identify:
+
+1. **Fenced blocks** in `~/.claude/CLAUDE.md` — these are managed by others (employer, other tools). Note their tags and line ranges. You will **read** these for insights but **never write to them**.
+2. **Personal section** — everything after the last fence closing tag. This is yours to update.
+3. **Repo rules** — the current `.claude/rules/*.md` files and `templates/user-claude.md` in this repo.
+
+Print a brief orientation:
+```
+CLAUDE.md: <N> lines total
+  Fenced blocks: <list tag names and line ranges, or "none">
+  Personal section: lines <N>–end (<M> lines)
+
+Repo: <N> rule files found
+```
+
+---
+
+## Step 2: Inbound — Repo → This Machine
+
+*Skip if argument is `outbound`.*
+
+**Goal:** Add anything from the repo's guidance that isn't already reflected anywhere in `~/.claude/CLAUDE.md` (personal section or fenced sections — check the whole file).
+
+### 2a. Identify gaps
+
+Compare repo guidance (rules + shared template) against the full CLAUDE.md content:
+
+- For each rule file and each meaningful section of `user-claude.md`: check if the substance is already present somewhere in CLAUDE.md (exact or paraphrased — don't flag things already covered)
+- Build a list of genuine gaps: guidance in the repo not reflected anywhere in CLAUDE.md
+
+### 2b. Propose additions
+
+For each gap, draft the text to add to the personal section. Group related items. Keep additions concise — these are personal reminders, not full rule docs.
+
+Present the proposed additions:
+
+```
+Inbound additions to personal section of ~/.claude/CLAUDE.md:
+
+1. [from rules/skill-authoring.md]
+   > AskUserQuestion requires 2–4 options per question...
+
+2. [from rules/python-packaging.md]
+   > Use [dependency-groups] not [tool.uv] dev-dependencies...
+
+Apply these? (yes / select / skip)
+```
+
+- `yes` — apply all
+- `select` — go through each one individually  
+- `skip` — skip inbound entirely
+
+### 2c. Apply
+
+Append approved additions to the personal section of `~/.claude/CLAUDE.md`. Add a comment header: `## Synced from agent-skills (<date>)` before the block if adding multiple items.
+
+---
+
+## Step 3: Outbound — This Machine → Repo
+
+*Skip if argument is `inbound`.*
+
+**Goal:** Find novel guidance on this machine not yet in the repo, and propose it as new or updated rule files via a PR.
+
+### 3a. Identify novel guidance
+
+Scan the entire `~/.claude/CLAUDE.md` — both fenced and personal sections — for guidance not already present in the repo's rules or shared template.
+
+When reading fenced sections managed by others:
+- Extract generalizable insights (patterns, practices, constraints) — not employer-specific content
+- Rephrase to be generic and universally applicable
+- Skip anything too specific to that employer's stack/context
+
+Build a list of candidates: novel guidance worth adding to the repo.
+
+### 3b. Triage candidates
+
+For each candidate, determine:
+- Is this genuinely novel vs. already covered (even loosely) in the repo?
+- Is it generalizable, or too specific to this machine/context?
+- Where should it live: new rule file, addition to existing rule file, or update to `templates/user-claude.md`?
+- If a rule file: what `paths` frontmatter scope applies?
+
+Present the triage:
+
+```
+Outbound candidates:
+
+1. [new rule: .claude/rules/foo.md, paths: ["**/*.ts"]]
+   > <proposed content summary>
+
+2. [add to: .claude/rules/skill-authoring.md]
+   > <proposed addition>
+
+3. [skip — too employer-specific]
+   > <reason>
+
+Proceed with candidates 1 and 2? (yes / select / skip)
+```
+
+### 3c. Write rule files
+
+For approved candidates:
+- Write or update the rule files in the repo
+- Apply correct `paths` frontmatter (consult `.claude/rules/rule-authoring.md`)
+- Keep content generic and universally applicable — no employer names, internal tool names, or proprietary context
+
+### 3d. Open PR
+
+If any rule files were written:
+
+1. Create a branch: `ambrose/sync-guidance-<date>` (use ISO date, e.g. `2026-04-08`)
+2. Commit: `"sync-guidance: add rules from work machine"`
+3. Open PR to main with a summary of what was added and where it came from (described generically)
+
+---
+
+## Step 4: Summary
+
+Print a clean summary of what was done:
+
+```
+Sync complete.
+
+Inbound: added N items to personal section of ~/.claude/CLAUDE.md
+Outbound: PR opened at <url> with N new/updated rule files
+
+Nothing was modified inside fenced blocks.
+```
+
+---
+
+## Guidelines
+
+- **Read-only for fenced blocks.** Never edit content between fence tags, regardless of which tool manages them.
+- **Write boundary is the personal section.** All edits to CLAUDE.md go after the last closing fence tag.
+- **Generic outbound only.** Anything going into the repo must be free of employer-specific context. Rephrase before proposing.
+- **Diff before proposing.** Don't propose additions already covered — check substance, not just exact text.
+- **No auto-apply.** Always show proposed changes and get confirmation before writing anything.

--- a/skills/sync-guidance/scripts/context.sh
+++ b/skills/sync-guidance/scripts/context.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Pre-loads sync context: reads ~/.claude/CLAUDE.md and repo rules for the skill prompt
+
+CLAUDE_MD="$HOME/.claude/CLAUDE.md"
+REPO_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+case "$1" in
+  claude-md)
+    # Output the full CLAUDE.md with fence boundaries annotated as JSON
+    if [ ! -f "$CLAUDE_MD" ]; then
+      echo '{"error": "~/.claude/CLAUDE.md not found"}'
+      exit 0
+    fi
+    python3 - "$CLAUDE_MD" <<'PYEOF'
+import sys, json, re
+
+path = sys.argv[1]
+content = open(path).read()
+lines = content.splitlines()
+
+# Detect all fenced blocks — any <tag>...</tag> wrapping multiple lines
+# Fence = opening tag on its own line, closing </tag> on its own line
+fences = []
+fence_stack = []
+for i, line in enumerate(lines):
+    open_match = re.match(r'^\s*<([a-zA-Z][a-zA-Z0-9_-]*)>\s*$', line)
+    close_match = re.match(r'^\s*</([a-zA-Z][a-zA-Z0-9_-]*)>\s*$', line)
+    if open_match:
+        fence_stack.append((open_match.group(1), i))
+    elif close_match and fence_stack:
+        tag, start = fence_stack[-1]
+        if tag == close_match.group(1):
+            fence_stack.pop()
+            fences.append({"tag": tag, "start_line": start + 1, "end_line": i + 1})
+
+# Personal section = content after the last fence (or all content if no fences)
+personal_start = 0
+if fences:
+    personal_start = max(f["end_line"] for f in fences)
+
+personal_lines = lines[personal_start:]
+# Strip leading blank lines
+while personal_lines and not personal_lines[0].strip():
+    personal_lines.pop(0)
+
+print(json.dumps({
+    "path": path,
+    "total_lines": len(lines),
+    "fences": fences,
+    "personal_start_line": personal_start + 1,
+    "personal_content": "\n".join(personal_lines),
+    "full_content": content,
+}))
+PYEOF
+    ;;
+
+  repo-rules)
+    # Output all rule files from .claude/rules/ as JSON
+    python3 - "$REPO_DIR" <<'PYEOF'
+import sys, json, os, re
+from pathlib import Path
+
+repo = Path(sys.argv[1])
+rules_dir = repo / ".claude" / "rules"
+templates_dir = repo / "templates"
+
+rules = []
+for f in sorted(rules_dir.glob("*.md")):
+    content = f.read_text()
+    # Extract paths frontmatter if present
+    paths = None
+    m = re.match(r'^---\s*\npaths:\s*(\[.*?\])\s*\n---\s*\n', content, re.DOTALL)
+    if m:
+        try:
+            paths = json.loads(m.group(1))
+        except Exception:
+            pass
+    rules.append({
+        "file": str(f.relative_to(repo)),
+        "paths": paths,
+        "content": content,
+    })
+
+# Also include templates/user-claude.md as the shared base
+user_template = templates_dir / "user-claude.md"
+shared_content = user_template.read_text() if user_template.exists() else ""
+
+print(json.dumps({
+    "rules": rules,
+    "shared_template": shared_content,
+    "repo": str(repo),
+}))
+PYEOF
+    ;;
+
+  git-status)
+    cd "$REPO_DIR" && git status --short 2>&1
+    ;;
+
+  *)
+    echo "Usage: context.sh <claude-md|repo-rules|git-status>" >&2
+    exit 1
+    ;;
+esac

--- a/templates/user-claude.md
+++ b/templates/user-claude.md
@@ -69,11 +69,37 @@ you discover new information.
 - **Batch commits before pushing** -- every push triggers CI and jobs do not self-cancel.
   Accumulate all changes locally, then push once when the work is ready for review.
 
-## Batch Edits via Scripts
+## Scaling Large Operations
+
+Before doing repetitive or large-scale work, choose the right execution strategy:
+
+### Deterministic bulk work — use a script
 
 When making the same or similar changes to 3+ files — or 3+ places in one file — write a
 quick Python script to do it in one pass instead of editing one-by-one. Save to `/tmp/` so it's
 transient. This is faster, cheaper on tokens, and less error-prone than N individual Edit calls.
+Same principle for discovery: if the task is "find all X matching Y," a script with `glob`/`grep`
+beats spawning agents.
+
+### Intelligent bulk work — fan out to sub-agents
+
+When the work requires judgment (authoring tests, writing documentation, reviewing code, applying
+context-dependent fixes), coordinate as a hub and delegate to parallel sub-agents:
+
+1. **Plan the work yourself first.** Identify every unit of work and its inputs. Don't delegate
+   planning — delegate execution.
+2. **Use the cheapest model that can handle the task.** Haiku for mechanical transforms, Sonnet
+   for anything requiring understanding. Reserve Opus for genuinely hard judgment calls.
+3. **Scope each agent tightly.** One task, one clear deliverable. Tell each agent exactly which
+   files to read and which to write. Specify what it should *not* do — no running tests, no
+   lint fixes, no exploration beyond the stated scope.
+4. **Separate reads from writes.** Discovery agents get read-only instructions. Authoring agents
+   get a precise spec and write to specific files. Mixing the two leads to agents wandering.
+5. **Batch and verify.** Don't fire off 50 agents and hope. Work in batches — send a wave, wait
+   for results, run verification (tests, lint, typecheck), fix issues, then send the next wave.
+   Catch drift early rather than debugging 50 interleaved failures.
+6. **Keep your own context clean.** The point of delegation is that agent results stay out of
+   your main context. Summarize outcomes; don't paste raw output back into the conversation.
 
 ## Code Organization
 

--- a/templates/user-claude.md
+++ b/templates/user-claude.md
@@ -84,11 +84,33 @@ transient. This is faster, cheaper on tokens, and less error-prone than N indivi
 - Look for relevant code and **verify with user** the right location/area when starting on new files
 - Write clean, maintainable code: extract reusable logic, follow DRY, use meaningful names, and keep
   functions/methods focused on a single responsibility
-- When touching existing code, improve what you touch -- but keep changes scoped; ask user if unsure
+- When touching existing code, improve what you touch. Genuine speculative refactors (reshaping
+  unrelated modules, adding abstractions for hypothetical future needs) are the only things to
+  keep out -- but cleanup, warning fixes, and obvious improvements in the files you're already
+  reading are **in scope by default**, not "maybe next PR" material.
 - **Leave no mess.** When something becomes unused or obsolete as part of your change -- a flag, a
   parameter, a branch, a helper -- remove it in the same change. Dead code that lingers becomes the
-  next engineer's confusion. If you notice something unrelated that should be cleaned up, point it
-  out rather than silently leaving it.
+  next engineer's confusion. If you notice something unrelated that should be cleaned up, fix it
+  too rather than just pointing it out and moving on.
+
+## Scope of Active Work
+
+**User-reported issues during a session are always in scope. Full stop.** Do not ask "should I
+also look at X?" when X is something the user raised in the same conversation. Do not propose
+deferring related findings to "a separate PR" as if organizational neatness were a value -- it
+isn't, and constantly narrowing scope is its own failure mode.
+
+- **If the user raised it, it's in scope.** No permission-seeking required.
+- **If you found it while investigating (Boy Scout), it's in scope by default.** Warnings, dead
+  code, broken checks, stale comments -- fix them in the same change. The only reason to pause is
+  if the fix is genuinely outsized (large refactor, cross-cutting, risks scope creep) -- in which
+  case, stop and discuss with the user.
+- **Single-issue PRs are not a virtue.** Bundling related fixes into one PR is fine and often
+  preferred. Never split work just to keep a PR "clean" -- that's churn, not hygiene. PRs are
+  session batches, not topically pure deliverables.
+- **Stop asking "is this in scope?"** If the question even occurs to you, the answer is almost
+  always yes. Do the work and report what you did. Reserve the scope question for genuine
+  off-topic tangents -- not adjacent cleanup inside files you're already editing.
 
 ## Bias Toward Action
 
@@ -131,6 +153,16 @@ context by only loading when relevant.
 
 - Always run verification (lint, typecheck, tests) before reporting work as complete.
   **All checks must pass** -- do not ignore failures just because they seem unrelated; ask user if unsure.
+- **Zero tolerance for warnings and diagnostics -- even "unrelated" ones.** The goal is a clean
+  slate: no warnings, lint errors, type errors, failing tests, or IDE/SourceKit diagnostics in
+  anything the project touches. When any surface during your work -- whether your change caused
+  them or they were already there -- the **default is to fix them in the same change**, even if
+  they appear unrelated to the task. Do not invoke "pre-existing" or "unrelated" as a reason to
+  move on; those are the exact rationalizations that let cruft accumulate until real regressions
+  hide in the noise. If a fix is genuinely outsized for the current task (large refactor, touches
+  many files, risks scope creep), **stop and discuss with the user** before deferring -- the user
+  decides, not you. Silent dismissal is never acceptable. Over time this bar should make
+  encounters with stray diagnostics rare, not routine.
 - Ask yourself if a staff+ engineer would approve of what you've written and iterate, if not.
 
 ### Verify the Full End-to-End Outcome

--- a/templates/user-claude.md
+++ b/templates/user-claude.md
@@ -133,6 +133,44 @@ context by only loading when relevant.
   **All checks must pass** -- do not ignore failures just because they seem unrelated; ask user if unsure.
 - Ask yourself if a staff+ engineer would approve of what you've written and iterate, if not.
 
+### Verify the Full End-to-End Outcome
+
+The goal is to verify what the actual *consumer* of the work would experience — not just that the
+technical artifact you produced exists or passed an isolated check. Who that consumer is depends on
+context: an end user opening a deployed app, a developer running a scaffolded project's own scripts,
+an analyst querying a pipeline's output dataset, a downstream team importing a published package.
+
+**Don't stop at the first positive signal.** Each layer of a system can succeed independently while
+the integration fails. A green build doesn't mean the app runs. A running container doesn't mean it
+serves real data. A generated file doesn't mean the command that reads it works. Keep verifying
+until you've confirmed the outcome from the consumer's point of view.
+
+**Use the same entry points the consumer would.** Verifying pieces independently — checking that
+files exist, that individual steps exited 0, that a health endpoint returns 200 — can miss
+integration mismatches that only appear when the system is exercised end-to-end the way it's
+actually used.
+
+**Upfront success criteria.** For complex multi-step tasks, list what "done" looks like *before*
+starting and confirm it matches expectations. This prevents the incremental-reveal pattern where
+each round of checking uncovers another unchecked layer.
+
+**Examples across different problem domains:**
+
+- *Deployed web + API + database:* The page renders real content → the frontend reaches the API →
+  the API returns live database rows → seed data is present. "Service is RUNNING" is not done.
+
+- *Scaffolded project template:* The generated project's own scripts (`install`, `build`, `test`)
+  all succeed end-to-end. Independently checking that expected files exist can miss wiring issues
+  between scaffolded pieces — verify using the same commands the developer would actually run.
+
+- *Data pipeline:* The output dataset contains the expected rows for known inputs — not just that
+  each transformation step exited 0. A pipeline can complete cleanly while producing empty or
+  malformed output if an upstream join silently drops records.
+
+- *Published package or library:* A fresh install in a new project can import the package and call
+  its exports. Build artifacts in `dist/` existing is not the same as the package being consumable
+  downstream — the `exports` map, `main` field, or peer dep resolution may still be broken.
+
 ## Blocked commands
 
 These commands will be blocked -- avoid generating them and use alternatives instead:


### PR DESCRIPTION
## Summary

Closes no specific issue — this is a batch of new skills and template improvements developed and validated through a real AWS deployment.

### New skills
- **deploy-aws** — Interactive App Runner + RDS deployment skill. Provisions ECR repos, RDS Postgres, IAM role, and App Runner services. Idempotent (state in `.deploy-aws.json`). Supports `update` and `cleanup` args.
- **sync-guidance** — Cross-machine CLAUDE.md sync. Reads current personal guidance, diffs against source, writes only to the unfenced personal section.

### deploy-aws improvements (from first real deployment run)
- **A7** — Post-deploy verification: health check + seed data query (GraphQL `{ users }` / tRPC fallback) confirms API → DB; Playwright headless browser waits for "API status: ok" to render confirms browser JS → API → DB full stack
- **A8** — Local smoke test before ECR push: builds native-arch image, polls health endpoint, shows container logs on failure — catches crashes before the 10-20 min App Runner cycle
- **A9** — `sslmode=no-verify` in DATABASE_URL for RDS SSL
- **A10** — Runs `db:push` + `db:seed` after RDS provision
- **A11** — `cleanup.py`: tears down App Runner → ECR → RDS → SG → IAM in correct dependency order
- Handles `CREATE_FAILED` services (delete + recreate), 20-min timeout for first deploys, linux/amd64 platform for Apple Silicon

### Template improvements (surfaced by Docker/AWS deployment)
- Switched API and db packages from `tsc` to `tsup` (fixes ESM extensionless imports that Node rejects)
- `packages/db`: `"main": "dist/index.js"` (was pointing at TypeScript source)
- `apps/api/Dockerfile`: copies workspace `node_modules` correctly for pnpm monorepo
- `nginx.conf`: `resolver` + `set $api_upstream` variable pattern for HTTPS App Runner proxy
- Defensive SSL options in `packages/db/src/index.ts` for RDS
- `docker-compose.containers.yml.j2`: full-stack container overlay (API + web + Postgres) for local pre-deploy testing
- `CLAUDE.md.j2`: documents the containers compose command

### create-repo improvements
- `resolve_versions`: validates cache covers all template-required keys before using it; auto-refreshes if any are missing (prevents `UndefinedError` when templates add new version keys)
- Added `tsup` and `tsx` to `PACKAGE_REGISTRY` and version fixtures

### Rules / conventions
- `python-packaging.md`: uv conventions, dep ranges, `botocore[crt]` for AWS auth
- `rule-authoring.md`: guidance on `paths` frontmatter scoping
- `skill-authoring.md`: full `AskUserQuestion` schema constraints (1-4 questions, 2-4 options, no iterative loops)
- `user-claude.md`: end-to-end verification guidance ("don't stop at the first positive signal")

## Verification

### Skills
- [x] Ran `deploy-aws` end-to-end against a real `fullstack-graphql` project (`testgraphql2`) — all services deployed, Playwright confirmed "API status: ok" rendered, seed data query returned alice + bob
- [x] Ran `deploy-aws cleanup` — all resources deleted cleanly

### Templates (create-repo)
- [x] Unit + structural tests: `make test` — 603 passing
- [x] `testgraphql2` scaffolded, set up, and deployed successfully