### PR TITLE
feat: /wtf correction capture skill (phase 1 of 3)

### DIFF
--- a/skills/wtf/README.md
+++ b/skills/wtf/README.md
@@ -1,0 +1,33 @@
+# /wtf — correction capture
+
+Mid-session capture skill for the WTF feedback loop. When you catch Claude doing something wrong, type:
+
+```
+/wtf <what went wrong>
+```
+
+The skill returns almost immediately:
+
+1. Writes a correction file to `~/.agent-skills/wtf/<timestamp>-<slug>.md` with frontmatter (session, cwd, branch), your verbatim message, and the last ~10 turns pulled from the session transcript.
+2. Fires `backlog-append.sh` in the background — it finds an open `WTF`-labeled issue in `ambroselittle/agent-skills` that isn't currently `In Progress` and appends your correction to its body, or creates a new issue if none is open.
+
+## Files
+
+| File | Role |
+|---|---|
+| `SKILL.md` | Orchestration prose read by Claude on `/wtf` invocation |
+| `scripts/capture.sh` | Writes the local correction file, prints its path |
+| `scripts/extract-turns.sh` | Reads transcript JSONL; emits last ~10 turns as markdown |
+| `scripts/backlog-append.sh` | Find-or-create the backlog issue; append the correction |
+
+## Where this fits
+
+The autonomous worker (see `scripts/wtf-worker.sh` once phase 2 lands) wakes up on a launchd schedule, drains the backlog, classifies each correction (behavioral guidance / rule / skill / hook / CLAUDE.md / upstream issue / no-action), and opens PRs against this repo. You review, request changes if needed, and the worker iterates on the next wake.
+
+Install the worker once phase 3 lands:
+
+```bash
+bash setup.sh --install-wtf-worker
+```
+
+Labels are self-bootstrapping — first `/wtf` invocation creates the `WTF` and `In Progress` labels on the repo if they don't exist.

--- a/skills/wtf/SKILL.md
+++ b/skills/wtf/SKILL.md
@@ -6,6 +6,42 @@ argument-hint: "<what went wrong>"
 
 # /wtf — Capture a correction
 
-When you catch me doing something wrong, type `/wtf <what went wrong>` to persist the correction. The skill returns quickly; the GitHub backlog update happens in the background.
+When the user catches you doing something wrong, they type `/wtf <what went wrong>`. This skill persists the correction so an autonomous worker can classify and fix it later. The skill returns in <1s; the GitHub backlog update happens in the background.
 
-Orchestration prose populated in the next task.
+**Arguments:** `$ARGUMENTS` — free-form description of what went wrong. The user's raw reaction is good; no need to sanitize.
+
+## Step 1: Capture locally (synchronous)
+
+Run the capture script, passing the user's message verbatim. Capture the file path it prints:
+
+```bash
+CAPTURE_FILE=$(~/.claude/skills/wtf/scripts/capture.sh "$ARGUMENTS")
+```
+
+This writes `~/.agent-skills/wtf/<timestamp>-<slug>.md` with frontmatter (session, cwd, branch), the user's verbatim message, and the last ~10 turns extracted from the transcript. Runs in well under a second.
+
+## Step 2: Queue the backlog append (asynchronous, non-blocking)
+
+Fire off the GitHub backlog append in the background so the skill returns immediately:
+
+```bash
+nohup ~/.claude/skills/wtf/scripts/backlog-append.sh "$CAPTURE_FILE" \
+  > ~/Library/Logs/wtf-backlog-append.log 2>&1 &
+disown
+```
+
+The background script looks for an open `WTF`-labeled issue in `ambroselittle/agent-skills` that isn't currently `In Progress`, appends this correction to its body, or creates a new issue if none is open. `disown` ensures it survives the skill returning.
+
+## Step 3: Report back
+
+Tell the user:
+
+- **Captured to:** `$CAPTURE_FILE`
+- **Backlog update:** running in background — check `~/Library/Logs/wtf-backlog-append.log` if anything seems off
+
+Be brief. The user was in the middle of something and just wants to confirm the capture landed. Do not summarize the correction back to them.
+
+## Notes
+
+- **Background append vs Agent spawn.** The plan originally specified spawning an `Agent` for the GH work. In implementation, the operations are fully deterministic (list → view → edit, or create), so a shell script fits `skill-authoring.md`'s "deterministic work should be scripts, not AI" guidance — faster, no LLM cost, and the fire-and-forget behavior is identical.
+- **Labels are self-bootstrapping.** `backlog-append.sh` idempotently ensures the `WTF` and `In Progress` labels exist on every run, so the skill works standalone even before the worker is installed via `setup.sh --install-wtf-worker`.

--- a/skills/wtf/SKILL.md
+++ b/skills/wtf/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: wtf
+description: Capture a mid-session correction for the autonomous worker to act on later. Writes a local file and appends to a rolling GitHub backlog issue in the background so you stay in flow.
+argument-hint: "<what went wrong>"
+---
+
+# /wtf — Capture a correction
+
+When you catch me doing something wrong, type `/wtf <what went wrong>` to persist the correction. The skill returns quickly; the GitHub backlog update happens in the background.
+
+Orchestration prose populated in the next task.

--- a/skills/wtf/SKILL.md
+++ b/skills/wtf/SKILL.md
@@ -25,12 +25,12 @@ This writes `~/.agent-skills/wtf/<timestamp>-<slug>.md` with frontmatter (sessio
 Fire off the GitHub backlog append in the background so the skill returns immediately:
 
 ```bash
-nohup ~/.claude/skills/wtf/scripts/backlog-append.sh "$CAPTURE_FILE" \
-  > ~/Library/Logs/wtf-backlog-append.log 2>&1 &
-disown
+mkdir -p ~/Library/Logs
+( nohup ~/.claude/skills/wtf/scripts/backlog-append.sh "$CAPTURE_FILE" \
+  > ~/Library/Logs/wtf-backlog-append.log 2>&1 & )
 ```
 
-The background script looks for an open `WTF`-labeled issue in `ambroselittle/agent-skills` that isn't currently `In Progress`, appends this correction to its body, or creates a new issue if none is open. `disown` ensures it survives the skill returning.
+The subshell-with-background pattern `( ... & )` detaches the process cleanly in both `bash` and `zsh` — no `disown` needed (which triggers a "no current job" warning on zsh). The background script looks for an open `WTF`-labeled issue in `ambroselittle/agent-skills` that isn't currently `In Progress`, appends this correction to its body, or creates a new issue if none is open.
 
 ## Step 3: Report back
 

--- a/skills/wtf/scripts/backlog-append.sh
+++ b/skills/wtf/scripts/backlog-append.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Appends a correction to the rolling WTF backlog issue in ambroselittle/agent-skills,
+# or creates a new issue if none is currently open-and-unclaimed.
+#
+# Usage: backlog-append.sh <correction-file-path>
+#
+# Intended to be run detached (nohup ... & disown) by the /wtf skill so the
+# skill returns immediately. Logs to stderr; prints the issue URL to stdout
+# on success.
+
+set -euo pipefail
+
+file="${1:-}"
+if [ -z "$file" ] || [ ! -f "$file" ]; then
+  echo "Usage: backlog-append.sh <correction-file-path>" >&2
+  exit 1
+fi
+
+REPO="ambroselittle/agent-skills"
+TITLE="WTF backlog"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI not found — skipping backlog append" >&2
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "gh not authenticated — skipping backlog append" >&2
+  exit 1
+fi
+
+# Ensure both labels exist on the repo. `--force` creates-or-updates, so this is
+# idempotent and safe on every invocation. Cheap bootstrap so the capture skill
+# works standalone without requiring `setup.sh --install-wtf-worker` first.
+gh label create WTF -R "$REPO" --color FF6347 \
+  --description "Correction captured via /wtf skill" --force >/dev/null 2>&1 || true
+gh label create "In Progress" -R "$REPO" --color FBCA04 \
+  --description "Active claim by an autonomous worker" --force >/dev/null 2>&1 || true
+
+# Strip YAML frontmatter (first ---...--- block) so the entry renders cleanly in GH.
+entry=$(awk '
+  /^---$/ {
+    if (!seen_open) { seen_open = 1; next }
+    if (!seen_close) { seen_close = 1; next }
+  }
+  seen_open && !seen_close { next }
+  seen_close { print }
+' "$file")
+
+marker="<!-- entry: $(basename "$file") -->"
+new_entry="${marker}
+
+${entry}"
+
+# Query: any open issue labeled WTF that isn't currently In Progress.
+existing=$(gh issue list \
+  -R "$REPO" \
+  --state open \
+  --label WTF \
+  --search '-label:"In Progress"' \
+  --json number,body,url \
+  --limit 1)
+
+count=$(printf '%s' "$existing" | jq 'length')
+
+if [ "$count" -gt 0 ]; then
+  num=$(printf '%s' "$existing" | jq -r '.[0].number')
+  url=$(printf '%s' "$existing" | jq -r '.[0].url')
+  existing_body=$(printf '%s' "$existing" | jq -r '.[0].body')
+  new_body="${existing_body}
+
+---
+
+${new_entry}"
+  gh issue edit "$num" -R "$REPO" --body "$new_body" >/dev/null
+  echo "Appended correction to $url" >&2
+  echo "$url"
+else
+  url=$(gh issue create \
+    -R "$REPO" \
+    --title "$TITLE" \
+    --label WTF \
+    --body "$new_entry")
+  echo "Created new backlog issue: $url" >&2
+  echo "$url"
+fi

--- a/skills/wtf/scripts/capture.sh
+++ b/skills/wtf/scripts/capture.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Writes a single correction-capture file to ~/.agent-skills/wtf/
+# and prints the absolute file path on stdout.
+#
+# Usage: capture.sh <message...>
+#
+# Environment:
+#   CLAUDE_SESSION_ID: optional; included in frontmatter when set.
+#
+# Exits non-zero only when no message is provided. All other failures
+# (git commands, transcript extraction) degrade gracefully.
+
+set -euo pipefail
+
+if [ $# -eq 0 ]; then
+  echo "Usage: capture.sh <message>" >&2
+  exit 1
+fi
+
+message="$*"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+
+# Timestamps — filename uses a compact sortable form, frontmatter uses full ISO 8601.
+ts_file=$(date -u +%Y%m%dT%H%M%SZ)
+ts_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# Slug from the message: lowercase, non-alnum collapsed to -, trimmed, max 40 chars.
+slug=$(printf '%s' "$message" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed -E 's/[^a-z0-9]+/-/g; s/^-//; s/-$//' \
+  | cut -c1-40 \
+  | sed -E 's/-$//')
+slug=${slug:-untitled}
+
+# Context — fall back gracefully if we're not in a git repo or git is unavailable.
+cwd="${PWD:-$(pwd)}"
+session_id="${CLAUDE_SESSION_ID:-unknown}"
+branch=$(git -C "$cwd" branch --show-current 2>/dev/null || echo "no-branch")
+
+# Pull the conversation tail from the transcript (degrades gracefully).
+turns=$("$script_dir/extract-turns.sh" "$cwd" 2>/dev/null || echo "(transcript unavailable)")
+
+# Destination directory — permissive on ~/.agent-skills/ per built-in-rules.
+dir="$HOME/.agent-skills/wtf"
+mkdir -p "$dir"
+
+# Atomic write: temp file in the same directory, then rename.
+tmpfile=$(mktemp "$dir/.tmp-XXXXXXXX")
+trap 'rm -f "$tmpfile"' EXIT
+
+cat > "$tmpfile" << EOF
+---
+timestamp: $ts_iso
+session_id: $session_id
+cwd: $cwd
+branch: $branch
+---
+
+# $slug
+
+## User said
+
+$message
+
+## Context
+
+- **Branch:** \`$branch\`
+- **Session:** \`$session_id\`
+- **Cwd:** \`$cwd\`
+
+## Transcript
+
+$turns
+
+## My take
+
+<!-- Optional. The worker classifier will determine the right action regardless. -->
+EOF
+
+outfile="$dir/${ts_file}-${slug}.md"
+mv "$tmpfile" "$outfile"
+trap - EXIT
+
+echo "$outfile"

--- a/skills/wtf/scripts/extract-turns.sh
+++ b/skills/wtf/scripts/extract-turns.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Extracts the last ~10 user/assistant turns from the Claude Code transcript
+# for the current session. Degrades gracefully if anything is missing.
+#
+# Usage: extract-turns.sh [cwd]
+#   cwd: optional; defaults to $PWD. Used to compute the Claude project slug.
+#
+# Environment:
+#   CLAUDE_SESSION_ID: required. The session ID injected by Claude Code.
+#
+# Output: markdown to stdout. On any failure, prints a "(transcript unavailable: ...)"
+# line and exits 0 so the caller never fails because of this helper.
+
+set -euo pipefail
+
+cwd="${1:-${PWD:-$(pwd)}}"
+session_id="${CLAUDE_SESSION_ID:-}"
+
+if [ -z "$session_id" ]; then
+  echo "(transcript unavailable: CLAUDE_SESSION_ID not set)"
+  exit 0
+fi
+
+# Claude Code project slug: replace / and . with - in the absolute path.
+slug=$(printf '%s' "$cwd" | tr '/.' '--')
+transcript="$HOME/.claude/projects/${slug}/${session_id}.jsonl"
+
+if [ ! -f "$transcript" ]; then
+  echo "(transcript unavailable: $transcript not found)"
+  exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "(transcript unavailable: jq not installed)"
+  exit 0
+fi
+
+# Pull last ~100 lines, keep only user/assistant turns, take the last 10,
+# then render each as markdown with a truncated content preview (~800 chars).
+tail -n 100 "$transcript" \
+  | jq -c 'select(.type == "user" or .type == "assistant") | select(.message.role == "user" or .message.role == "assistant")' 2>/dev/null \
+  | tail -n 10 \
+  | jq -r '
+      (.message.role | ascii_upcase) as $role |
+      (
+        if (.message.content | type) == "string" then
+          .message.content
+        else
+          (.message.content | map(
+            if .type == "text" then .text
+            elif .type == "tool_use" then "[tool-use: \(.name // "?")]"
+            elif .type == "tool_result" then "[tool-result]"
+            else ""
+            end
+          ) | join("\n"))
+        end
+      ) as $content |
+      "### \($role)\n\n\($content | .[0:800])"
+    ' 2>/dev/null \
+  || echo "(transcript unavailable: parse error)"


### PR DESCRIPTION
## Summary

Adds the `/wtf` skill — mid-session correction capture that persists a correction to `~/.agent-skills/wtf/<ts>-<slug>.md` and fires a background script to append it to a rolling `WTF`-labeled backlog issue in this repo. Returns to the user in ~50ms so capture never breaks flow.

This is phase 1 of 3 (phase 2 = autonomous worker + classifier, phase 3 = launchd install). Stacked PRs follow — this phase ships a usable capture skill standalone: even without the worker, you get a local log and a running GitHub backlog to act on manually.

Replaces the abandoned `/learn` approach with fire-and-forget capture instead of end-of-session ceremony.

## Key decisions

- **Shell script, not Agent, for the background GH append.** The plan originally called for spawning an `Agent` for the backlog update. On implementation, the flow (`gh issue list` → `edit` or `create`) is fully deterministic, so per `.claude/rules/skill-authoring.md` ("deterministic work should be scripts, not AI") it's cleaner as `scripts/backlog-append.sh`. Same fire-and-forget behavior, no LLM cost.
- **Labels self-bootstrap.** `backlog-append.sh` idempotently ensures the `WTF` and `In Progress` labels exist via `gh label create --force`. Makes the capture skill work standalone before the phase-3 installer runs.
- **Title-case label names.** `WTF` (acronym, all caps) and `In Progress` (title case, space) per user aesthetic preference.
- **Subshell detachment pattern `( cmd & )`.** Initially used `& disown`, but zsh emits "disown: no current job" because the background process has already left scope. Subshell-with-background works cleanly on both bash and zsh — caught during E2E verification.
- **Transcript extraction from the on-disk JSONL.** Reads `~/.claude/projects/<slug>/<session-id>.jsonl` using `$CLAUDE_SESSION_ID` + `$PWD` to compute the slug. Degrades gracefully (emits `(transcript unavailable: ...)`) when jq is missing, the session ID is unset, or the file has been compacted away.

## Verification

### Skills
- [x] Manually ran `/wtf` end-to-end: capture file landed at `~/.agent-skills/wtf/*.md`, background script created then appended to a backlog issue, timing ~50ms
- [x] Verified label bootstrap: both `WTF` and `In Progress` labels created on first run
- [x] Tested edge cases: missing `CLAUDE_SESSION_ID` (graceful), missing transcript file (graceful), second capture appends to existing issue rather than creating a new one
- [x] Test issues #30 and #31 created and closed as part of verification; no residue

### Setup / CI / Infra
- [x] `make check` (format + lint) passing
- [x] `make test` — 449 hook-engine tests + 154 create-repo tests all passing

## Follow-up (phase 2 and phase 3)

- **Phase 2** — autonomous worker script + classifier prompt (`scripts/wtf-worker.sh`, `scripts/wtf-worker-prompt.md`). Drains the backlog, classifies each correction into one of 7 buckets, opens PRs, iterates on PRs with `CHANGES_REQUESTED` review state.
- **Phase 3** — launchd plist + `setup.sh --install-wtf-worker` opt-in install.
- **Phase 4** — dogfood + prompt tuning, as follow-up commits once the full system is running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)