### PR TITLE
feat: /wtf worker + classifier prompt (phase 2 of 3)

### DIFF
--- a/scripts/wtf-worker-prompt.md
+++ b/scripts/wtf-worker-prompt.md
@@ -1,0 +1,160 @@
+# Role: WTF worker
+
+You are the autonomous improvement agent for `ambroselittle/agent-skills`. You were invoked by a launchd-scheduled wrapper (`scripts/wtf-worker.sh`). The invocation preamble at the top of this prompt tells you the mode (`new` or `iterate`), the issue or PR number, and the work item's body.
+
+Your job: produce a PR (or update an existing one) that addresses the correction(s). Go end-to-end — classify, edit, test, commit, push, PR, manage labels.
+
+## Environment
+
+- **Working directory:** a fresh `--depth 1` clone of `ambroselittle/agent-skills` under `/tmp/wtf-worker-*`. The wrapper has already `cd`'d into it.
+- **Auth:** `gh` and `git` are authenticated with the user's credentials.
+- **Tools:** full shell + filesystem access; `--dangerously-skip-permissions` is in effect.
+- **Model:** Sonnet.
+
+## Mode: `new`
+
+The issue body is a rolling backlog — one or more correction entries appended over time, separated by `---` lines. Each entry is a markdown block with an `<!-- entry: <filename>.md -->` marker and sections: **User said**, **Context** (branch, session, cwd), **Transcript**, optionally **My take**.
+
+### Step 1 — parse
+
+Split the body at top-level `---` separators. Extract each entry's user message, context, and any transcript hints.
+
+### Step 2 — classify
+
+Pick exactly ONE target per entry:
+
+| # | Category | Where it lands |
+|---|---|---|
+| 1 | **Behavioral guidance** (how Claude should work) | `templates/ambroselittle.md` (user-specific) or `templates/user-claude.md` (universal) — decide by whether the preference is Ambrose-only or anyone-would-benefit |
+| 2 | **Rule** (project-specific directive) | `.claude/rules/<topic>.md` — path-scoped (with `paths:` frontmatter) if it only applies to certain files, unscoped otherwise |
+| 3 | **Skill** (behavior of an existing skill, or a new one) | `skills/<name>/SKILL.md` or supporting files; rarely, a new `skills/<name>/` |
+| 4 | **Hook** (PreToolUse rule) | `hooks/PreToolUse/rules.json` + paired test in `hooks/PreToolUse/tests/rules/` (convention is enforced — see `hooks/PreToolUse/CLAUDE.md`) |
+| 5 | **CLAUDE.md** (repo orientation, structural facts) | `CLAUDE.md` at the repo root. Rare — most things are behavior, not orientation. |
+| 6 | **Upstream repo issue** (correction is about a different repo) | File an issue there: `gh issue create -R <owner>/<repo> --title "..." --body "..."`. No local changes. |
+| 7 | **No-action** (already fixed, one-off, or unactionable) | Close the backlog issue with a comment explaining why. |
+
+Prefer making the smallest reversible change. When in doubt between categories, pick the one with narrower scope (e.g. rule before skill, guidance before rule).
+
+### Step 3 — make the edits
+
+For categories 1–5, edit the relevant file(s) using the tools available. For category 6, file upstream issues. For category 7, no edits.
+
+### Step 4 — verify
+
+- Always: `make test`
+- **Conditionally:** if `git diff --name-only main` includes any path under `skills/create-repo/templates/`, also run `make test-scaffolds TEMPLATE=all`. Otherwise skip (these take ~3min and the CI equivalent has the same path filter — see `.github/workflows/ci.yml`).
+- Formatting/lint: `make check` should be clean.
+
+If tests fail on a change you made, narrow the diff and re-test. If still failing after 2 attempts, stop and comment on the issue with what broke — don't fight it.
+
+### Step 5 — commit + push
+
+One commit per logical entry (or group closely-related entries). Descriptive message — "fix(rule): foo" or "docs(ambroselittle): bar" style. Then:
+
+```bash
+git checkout -b wtf/<issue-N>-<short-slug>
+git push -u origin HEAD
+```
+
+### Step 6 — open the PR
+
+```bash
+gh pr create \
+  --title "wtf(#<N>): <short summary>" \
+  --label WTF \
+  --assignee @me \
+  --body "..."
+```
+
+PR body structure:
+
+```markdown
+## Summary
+
+Brief paragraph — what was corrected, at a high level.
+
+## Entries addressed
+
+### Entry 1: <short title>
+- **Classification:** <category>
+- **Action:** <what you did, where>
+
+### Entry 2: ...
+
+## Verification
+
+- [x] `make test`
+- [ ] `make test-scaffolds TEMPLATE=all` (skipped — no template changes)
+  — or —
+- [x] `make test-scaffolds TEMPLATE=all`
+
+Closes #<issue-N>
+```
+
+Use `Closes #<N>` so the merge auto-closes the backlog issue.
+
+### Step 7 — label management
+
+| Outcome | Action |
+|---|---|
+| **All entries processed, PR opened** | Leave `In Progress` on the issue. Merge of the PR will close the issue; labels become moot. |
+| **Partial success** (some entries done, others failed) | Open the PR with the done entries. Comment on the issue listing the failed ones. Remove `In Progress` from the issue so the remaining entries re-queue: `gh issue edit <N> --remove-label "In Progress"`. The PR should NOT use `Closes #<N>` in this case — use `Refs #<N>` instead. |
+| **No-action only** (category 7 for all entries) | Close the issue: `gh issue close <N> --comment "..."`. No PR. |
+| **Upstream-only** | File upstream issues, then close this repo's issue with a comment linking them. No local PR. |
+
+## Mode: `iterate`
+
+You're revisiting an open PR that a human reviewer marked `CHANGES_REQUESTED`. The wrapper already checked out the PR's head branch.
+
+### Step 1 — read the feedback
+
+```bash
+gh pr view <pr-number> --json reviews,comments,files
+```
+
+Focus on the most recent `CHANGES_REQUESTED` review and any inline comments. Older reviews may have already been addressed. Inline comments (per-line review comments) are `gh api repos/<owner>/<repo>/pulls/<pr>/comments`.
+
+### Step 2 — address the feedback
+
+Edit the code. Don't just respond in comments. Fix what they asked for. If a request is genuinely off-base (would break things, contradicts other reviewer input, or is unclear), respond with a comment explaining the tradeoff — but that's a rare case.
+
+### Step 3 — verify
+
+Same as new-work Step 4: `make test` always, scaffold E2E only when templates changed.
+
+### Step 4 — commit + push
+
+Commit message pattern: `review: address <what>`. Push to the same branch. No new branch, no new PR.
+
+### Step 5 — re-request review + drop claim
+
+```bash
+gh pr comment <pr-number> --body "Addressed the review feedback. Re-requesting review."
+gh pr edit <pr-number> --remove-label "In Progress"
+```
+
+The `In Progress` removal re-opens the PR for the next worker wake in case the reviewer comes back with another round.
+
+## Guardrails
+
+- **Scope:** work only in the checkout. Don't modify other files, other repos, or system state.
+- **No destructive git:** never `--force`, `--no-verify`, `reset --hard`, or `checkout -- .`. If something goes sideways, commit what you have and stop.
+- **No silent skips:** if you can't do something an entry asks, log it explicitly (comment on the issue/PR). Silent failure is worse than visible failure.
+- **Verify before push:** `make test` must pass before `git push`. No exceptions.
+- **Secrets:** if an entry mentions credentials, API keys, or `.env` values, do not include them in commits or PR bodies.
+
+## Output
+
+At the very end, emit a single status line so the wrapper can parse it:
+
+```
+WTF-WORKER-STATUS: <status>
+```
+
+Where `<status>` is one of:
+
+- `completed-pr-<N>` — all entries addressed, PR N opened (new) or updated (iterate)
+- `partial-pr-<N>` — PR N opened with a subset; issue left open with remaining entries
+- `upstream-only` — filed upstream issue(s); local issue closed
+- `no-action` — no changes needed; issue closed with explanation
+- `failed` — could not complete; commented on issue/PR with details

--- a/scripts/wtf-worker.sh
+++ b/scripts/wtf-worker.sh
@@ -1,0 +1,231 @@
+#!/bin/bash
+# Autonomous worker for the /wtf correction backlog.
+#
+# Runs on a launchd schedule. Looks for actionable work:
+#   1) A WTF-labeled open issue without an "In Progress" label → new-work mode
+#   2) A WTF-labeled open PR in CHANGES_REQUESTED review state without
+#      "In Progress" → iterate mode
+#
+# When it finds work, it claims the item by adding "In Progress",
+# shallow-clones ambroselittle/agent-skills to /tmp/, and hands off to
+# `claude -p` with scripts/wtf-worker-prompt.md prepended to an invocation
+# header describing the work item. The Claude session does the actual
+# classification, edits, tests, push, and PR creation/update.
+#
+# Usage: wtf-worker.sh [--dry-run]
+#
+# --dry-run: find work and print the planned action without claiming,
+#            cloning, or invoking Claude. Useful for smoke-testing and
+#            launchd verification.
+
+set -euo pipefail
+
+REPO="ambroselittle/agent-skills"
+LOG_DIR="$HOME/Library/Logs"
+LOG_FILE="$LOG_DIR/wtf-worker.log"
+LOCK_DIR="$HOME/.agent-skills/.wtf-worker.lock.d"
+STALE_LOCK_MINUTES=60
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROMPT_FILE="$SCRIPT_DIR/wtf-worker-prompt.md"
+
+DRY_RUN=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    --help|-h)
+      sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown flag: $arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+mkdir -p "$LOG_DIR" "$HOME/.agent-skills"
+
+log() {
+  printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" | tee -a "$LOG_FILE" >&2
+}
+
+# Lockdir acquisition with stale cleanup. `mkdir` is atomic on POSIX — if
+# two workers race, only one succeeds. If an old lockdir exceeds the stale
+# threshold, we reclaim it (previous worker presumably died).
+if [ -d "$LOCK_DIR" ]; then
+  if find "$LOCK_DIR" -maxdepth 0 -mmin +$STALE_LOCK_MINUTES 2>/dev/null | read -r; then
+    log "stale lockdir detected (>${STALE_LOCK_MINUTES}min), reclaiming"
+    rmdir "$LOCK_DIR" 2>/dev/null || rm -rf "$LOCK_DIR"
+  else
+    log "lockdir held by another worker, exiting"
+    exit 0
+  fi
+fi
+
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  log "failed to acquire lockdir (race with another worker), exiting"
+  exit 0
+fi
+
+# Cleanup trap: clear the lockdir, nuke the clone, and drop the claim if
+# the worker exits abnormally while holding a work item.
+CLONE_DIR=""
+WORK_TYPE=""
+WORK_NUM=""
+CLAIMED=0
+
+cleanup() {
+  local rc=$?
+  if [ -n "$CLONE_DIR" ] && [ -d "$CLONE_DIR" ]; then
+    rm -rf "$CLONE_DIR"
+  fi
+  rmdir "$LOCK_DIR" 2>/dev/null || true
+  if [ "$rc" -ne 0 ] && [ "$CLAIMED" -eq 1 ]; then
+    log "worker failed (rc=$rc), dropping claim on $WORK_TYPE #$WORK_NUM"
+    gh "$WORK_TYPE" edit "$WORK_NUM" -R "$REPO" --remove-label "In Progress" \
+      >/dev/null 2>&1 || true
+    local tail_log
+    tail_log=$(tail -20 "$LOG_FILE" 2>/dev/null | sed 's/`/\\`/g')
+    gh "$WORK_TYPE" comment "$WORK_NUM" -R "$REPO" \
+      --body "Worker failed (rc=$rc). Tail of log:
+
+\`\`\`
+$tail_log
+\`\`\`" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+# 3-attempt retry for transient gh failures. Increasing backoff.
+gh_retry() {
+  local max=3
+  local attempt=1
+  while true; do
+    if "$@"; then return 0; fi
+    if [ "$attempt" -ge "$max" ]; then return 1; fi
+    log "gh call failed, retry $attempt/$max"
+    sleep $((attempt * 2))
+    attempt=$((attempt + 1))
+  done
+}
+
+log "worker starting (dry-run=$DRY_RUN)"
+
+# ----- Phase 1: find work -----
+
+MODE=""
+work_url=""
+work_body=""
+work_head=""
+
+new_work=$(gh_retry gh issue list \
+  -R "$REPO" \
+  --state open \
+  --label WTF \
+  --search '-label:"In Progress"' \
+  --json number,url,body \
+  --limit 1)
+
+if [ "$(printf '%s' "$new_work" | jq 'length')" -gt 0 ]; then
+  WORK_TYPE="issue"
+  WORK_NUM=$(printf '%s' "$new_work" | jq -r '.[0].number')
+  work_url=$(printf '%s' "$new_work" | jq -r '.[0].url')
+  work_body=$(printf '%s' "$new_work" | jq -r '.[0].body')
+  MODE="new"
+else
+  iter_work=$(gh_retry gh pr list \
+    -R "$REPO" \
+    --state open \
+    --label WTF \
+    --search 'review:changes-requested -label:"In Progress"' \
+    --json number,url,body,headRefName \
+    --limit 1)
+
+  if [ "$(printf '%s' "$iter_work" | jq 'length')" -gt 0 ]; then
+    WORK_TYPE="pr"
+    WORK_NUM=$(printf '%s' "$iter_work" | jq -r '.[0].number')
+    work_url=$(printf '%s' "$iter_work" | jq -r '.[0].url')
+    work_body=$(printf '%s' "$iter_work" | jq -r '.[0].body')
+    work_head=$(printf '%s' "$iter_work" | jq -r '.[0].headRefName')
+    MODE="iterate"
+  else
+    log "no work found, exiting cleanly"
+    exit 0
+  fi
+fi
+
+log "found work: $WORK_TYPE #$WORK_NUM ($MODE) — $work_url"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  log "DRY RUN — would claim, clone, and invoke claude"
+  log "  mode: $MODE"
+  if [ -n "$work_head" ]; then
+    log "  head branch: $work_head"
+  fi
+  log "  body preview (first 20 lines):"
+  printf '%s\n' "$work_body" | head -20 | sed 's/^/    | /' | tee -a "$LOG_FILE" >&2
+  exit 0
+fi
+
+# ----- Phase 2: claim -----
+
+log "claiming $WORK_TYPE #$WORK_NUM with 'In Progress' label"
+gh_retry gh "$WORK_TYPE" edit "$WORK_NUM" -R "$REPO" --add-label "In Progress" >/dev/null
+CLAIMED=1
+
+# ----- Phase 3: shallow clone -----
+
+CLONE_DIR="/tmp/wtf-worker-${WORK_NUM}-$(date -u +%Y%m%dT%H%M%SZ)"
+log "cloning $REPO to $CLONE_DIR (--depth 1)"
+git clone --depth 1 "git@github.com:$REPO.git" "$CLONE_DIR" 2>&1 | tee -a "$LOG_FILE" >&2
+
+if [ "$MODE" = "iterate" ]; then
+  cd "$CLONE_DIR"
+  log "fetching PR head branch: $work_head"
+  git fetch --depth 1 origin "$work_head":"$work_head" 2>&1 | tee -a "$LOG_FILE" >&2
+  git checkout "$work_head"
+fi
+
+# ----- Phase 4: build prompt + invoke claude -----
+
+if [ ! -f "$PROMPT_FILE" ]; then
+  log "ERROR: prompt template not found at $PROMPT_FILE"
+  exit 1
+fi
+
+# Assemble prompt: invocation-specific context preamble, then the template
+# contents verbatim. Using printf rather than a heredoc avoids expansion
+# surprises on the template body.
+prompt=$(
+  printf '# WTF worker invocation\n\n'
+  printf -- '- **Mode:** %s\n' "$MODE"
+  printf -- '- **Type:** %s\n' "$WORK_TYPE"
+  printf -- '- **Number:** #%s\n' "$WORK_NUM"
+  printf -- '- **URL:** %s\n' "$work_url"
+  if [ -n "$work_head" ]; then
+    printf -- '- **Head branch:** %s\n' "$work_head"
+  fi
+  printf '\n## Body of the %s\n\n' "$WORK_TYPE"
+  printf '```\n%s\n```\n\n' "$work_body"
+  printf -- '---\n\n'
+  cat "$PROMPT_FILE"
+)
+
+log "invoking claude for $WORK_TYPE #$WORK_NUM"
+cd "$CLONE_DIR"
+
+# Claude handles all label management after this point (per the prompt):
+#   - On success: leaves labels as the PR lifecycle dictates
+#   - On partial success or no-action: removes "In Progress" and comments
+#   - On iterate success: removes "In Progress" from the PR
+# If claude -p itself fails, the trap removes "In Progress" as a fallback.
+if ! claude -p "$prompt" \
+     --model sonnet \
+     --dangerously-skip-permissions \
+     --no-session-persistence \
+     2>&1 | tee -a "$LOG_FILE" >&2; then
+  log "claude -p invocation returned non-zero"
+  exit 1
+fi
+
+log "worker completed $WORK_TYPE #$WORK_NUM"


### PR DESCRIPTION
## Summary

Adds the autonomous worker that drains the `/wtf` backlog. A launchd-scheduled shell script (`scripts/wtf-worker.sh`) finds actionable work — either a WTF-labeled open issue without "In Progress" (new-work mode) or a WTF-labeled PR in CHANGES_REQUESTED without "In Progress" (iterate mode) — claims it by adding "In Progress", shallow-clones this repo to `/tmp/`, and hands off to `claude -p` with `scripts/wtf-worker-prompt.md` prepended to an invocation header. The Claude session does the actual classification, edits, tests, push, and PR lifecycle.

Phase 3 follows with the launchd plist + opt-in `setup.sh --install-wtf-worker`. Until then, you can run the worker manually — `scripts/wtf-worker.sh --dry-run` to smoke-test, `scripts/wtf-worker.sh` to actually work a queue item.

Depends on #32 (phase 1, already merged).

## Key decisions

- **Worker is pure orchestration shell; Claude does the intelligence.** The shell script handles the deterministic stuff (finding work, claiming, cloning, logging, failure recovery). The classifier, edits, test selection, and PR creation happen inside the `claude -p` invocation. This split keeps the shell script stable (rare changes) and concentrates the tunable surface in one markdown file.
- **`--dry-run` lives alongside the core script, not as a follow-up commit.** The plan's task 3 called for `--dry-run` as a separate step, but it's essential for smoke-testing detection without side effects. Combined into the worker-script commit so the script is testable from day one.
- **Labels are Claude's responsibility after the claim.** The shell trap only removes "In Progress" on script-level failures (network, clone failure). Every success path — full, partial, no-action, iterate — has Claude manage labels based on outcome per the prompt spec. Keeps the wrapper simple.
- **Shallow clone over git worktree.** Always fresh from `origin/main`, not inheriting any local stale state. Modern git handles shallow push fine.
- **lockdir via `mkdir` with 60-min stale cleanup.** Atomic on POSIX; handles the rare case of launchd re-firing while a previous run is stuck. Given the 2-hour schedule (phase 3), concurrency is near-impossible — but the guard is ~10 lines and costs nothing.
- **`claude -p --dangerously-skip-permissions --model sonnet --no-session-persistence`.** Autonomy requires bypass (there's no human to approve prompts); Sonnet is the right price/capability tradeoff for this classification+edit workload; no session persistence avoids transcript noise for throwaway runs.
- **Scaffold E2E skipped by default.** The prompt explicitly instructs Claude to skip `make test-scaffolds TEMPLATE=all` unless the diff touches `skills/create-repo/templates/`. Matches the path filter already in `.github/workflows/ci.yml` (commit 15cced3). Keeps worker wall time reasonable.

## Verification

### Skills
- [x] Manually ran `scripts/wtf-worker.sh --dry-run` against a synthetic WTF-labeled issue — detected it, logged body preview, cleanup trap released the lockdir
- [x] Verified empty-queue case — "no work found, exiting cleanly"
- [x] Test issue (#33) closed as part of cleanup; no residue

### Setup / CI / Infra
- [x] `make check` (format + lint) passing
- [x] `make test` — 449 hook-engine + 154 create-repo tests passing

## Not yet verified (deferred to dogfood in phase 4)

- The `claude -p` invocation itself against a real correction. The classifier prompt is comprehensive but untuned. Expect at least one round of prompt refinement after the first real correction lands.
- The iterate-mode path. Will exercise in dogfood by requesting changes on a real worker PR.
- The partial-success label-management flow. Will only matter once a multi-entry backlog issue exists.

## Follow-up (phase 3)

- `templates/wtf-worker.plist.template` with placeholders
- `scripts/wtf-worker-install.sh` (install/uninstall modes)
- `setup.sh --install-wtf-worker` / `--uninstall-wtf-worker` flags
- Docs on status/logs/troubleshooting

🤖 Generated with [Claude Code](https://claude.com/claude-code)