### PR TITLE
wtf(#34): allow rsync without prompting

### DIFF
--- a/hooks/PreToolUse/built-in-rules.json
+++ b/hooks/PreToolUse/built-in-rules.json
@@ -3,6 +3,7 @@
   "allow": [
     "Bash(~/.claude/skills/*/scripts/*.sh)",
     "Bash(~/.claude/skills/*/scripts/*.sh *)",
+    "Bash(rsync *)",
     "Read",
     "Write",
     "Edit",

--- a/hooks/PreToolUse/tests/rules/test_allow-bash-commands.py
+++ b/hooks/PreToolUse/tests/rules/test_allow-bash-commands.py
@@ -200,3 +200,16 @@ def test_rdme_cli_allowed(rule):
     assert (
         evaluate(_bash("result=$(npx rdme docs upload --key=$KEY)"), [rule])["decision"] == "allow"
     )
+
+
+def test_rsync_local(rule):
+    """rsync between local directories → allow."""
+    assert evaluate(_bash("rsync -a --delete src/ dest/"), [rule])["decision"] == "allow"
+
+
+def test_rsync_with_flags(rule):
+    """rsync with verbose and progress flags → allow."""
+    assert (
+        evaluate(_bash("rsync -avz --progress /tmp/build/ /tmp/deploy/"), [rule])["decision"]
+        == "allow"
+    )


### PR DESCRIPTION
## Summary

User was getting approval prompts when running `rsync`. The PreToolUse hook's `allow-bash-safe` rule already permits rsync at engine-evaluation time (it is not in `_UNSAFE`), but when the hook does not run — e.g. during skill frontmatter invocations — Claude Code falls back to `settings.json` permissions, which had no explicit `rsync` entry. Adding `Bash(rsync *)` to `built-in-rules.json` ensures silent approval regardless of whether the hook fires.

## Entries addressed

### Entry 1: having-to-approve-rsync
- **Classification:** Hook (category 4) — permissions / allowed list
- **Action:** Added `"Bash(rsync *)"` to `hooks/PreToolUse/built-in-rules.json` allow list; added two explicit `test_rsync_*` tests to `test_allow-bash-commands.py` confirming the hook already permits rsync via `allow-bash-safe`

## Verification

- [x] `make check`
- [x] `make test` (451 hook tests passed, 154 create-repo tests passed)
- [ ] `make test-scaffolds TEMPLATE=all` (skipped — no template changes)

Closes #34