### PR TITLE
feat: /wtf worker launchd install + TCC fixes (phase 3 of 3)

### DIFF
--- a/scripts/wtf-worker-install.sh
+++ b/scripts/wtf-worker-install.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Installs or uninstalls the WTF worker launchd job by rendering
+# templates/wtf-worker.plist.template into ~/Library/LaunchAgents/ and
+# managing the launchctl lifecycle.
+#
+# Usage: wtf-worker-install.sh <install|uninstall> [--test]
+#
+# install [--test]: renders the plist, loads the job; with --test also
+#                   fires an immediate run and tails the log for a few
+#                   seconds so you can see it succeed.
+# uninstall:        unloads the job and removes the plist.
+#
+# Called indirectly by `bash setup.sh --install-wtf-worker` /
+# `--uninstall-wtf-worker`.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMPLATE="$REPO_ROOT/templates/wtf-worker.plist.template"
+LABEL="com.ambroselittle.wtf-worker"
+PLIST_DEST="$HOME/Library/LaunchAgents/$LABEL.plist"
+LOG_DIR="$HOME/Library/Logs"
+WORKER_LOG="$LOG_DIR/wtf-worker.log"
+
+mode="${1:-}"
+test_flag=0
+if [ "${2:-}" = "--test" ]; then
+  test_flag=1
+fi
+
+case "$mode" in
+  install)
+    if [ ! -f "$TEMPLATE" ]; then
+      echo "ERROR: template not found at $TEMPLATE" >&2
+      exit 1
+    fi
+
+    mkdir -p "$(dirname "$PLIST_DEST")" "$LOG_DIR"
+
+    # Render placeholders. Using pipe separators in sed since paths contain /.
+    sed -e "s|{{REPO_ROOT}}|$REPO_ROOT|g" \
+        -e "s|{{HOME}}|$HOME|g" \
+        "$TEMPLATE" > "$PLIST_DEST"
+
+    # Idempotent reload: unload any previous version, then load.
+    launchctl unload "$PLIST_DEST" 2>/dev/null || true
+    launchctl load "$PLIST_DEST"
+
+    echo "✓ Installed $LABEL"
+    echo "  Plist:  $PLIST_DEST"
+    echo "  Repo:   $REPO_ROOT"
+    echo "  Logs:   $LOG_DIR/wtf-worker.log, wtf-worker.out.log, wtf-worker.err.log"
+    echo "  Status: launchctl list | grep wtf-worker"
+    echo "  Manual run: launchctl start $LABEL"
+
+    if [ "$test_flag" -eq 1 ]; then
+      echo ""
+      echo "→ Firing an immediate test run..."
+      launchctl start "$LABEL"
+      sleep 3
+      echo ""
+      echo "--- Tail of $WORKER_LOG ---"
+      tail -15 "$WORKER_LOG" 2>/dev/null || echo "(log not yet written — worker may still be starting)"
+    fi
+    ;;
+
+  uninstall)
+    if [ -f "$PLIST_DEST" ]; then
+      launchctl unload "$PLIST_DEST" 2>/dev/null || true
+      rm -f "$PLIST_DEST"
+      echo "✓ Uninstalled $LABEL"
+    else
+      echo "· Not installed (no plist at $PLIST_DEST)"
+    fi
+    ;;
+
+  ""|--help|-h)
+    sed -n '2,15p' "$0" | sed 's/^# \{0,1\}//'
+    ;;
+
+  *)
+    echo "Unknown mode: $mode" >&2
+    echo "Usage: wtf-worker-install.sh <install|uninstall> [--test]" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/wtf-worker-install.sh
+++ b/scripts/wtf-worker-install.sh
@@ -36,7 +36,26 @@ case "$mode" in
       exit 1
     fi
 
-    mkdir -p "$(dirname "$PLIST_DEST")" "$LOG_DIR"
+    mkdir -p "$(dirname "$PLIST_DEST")" "$LOG_DIR" "$HOME/.agent-skills"
+
+    # Snapshot the user's gitconfig to a launchd-accessible location.
+    #
+    # macOS TCC blocks launchd agents from reading iCloud-synced paths
+    # (~/Library/Mobile Documents/...). Users commonly symlink their
+    # dotfiles into iCloud, which breaks git inside launchd ("unable to
+    # access '~/.gitconfig': Operation not permitted"). We resolve the
+    # symlink at install time (when we're in the user session and have
+    # full permissions) and write a plain copy under ~/.agent-skills/,
+    # which the launchd agent CAN read. The plist points
+    # GIT_CONFIG_GLOBAL at that snapshot.
+    GITCONFIG_SNAPSHOT="$HOME/.agent-skills/wtf-worker.gitconfig"
+    if [ -r "$HOME/.gitconfig" ]; then
+      cat "$HOME/.gitconfig" > "$GITCONFIG_SNAPSHOT"
+      echo "  Gitconfig snapshot: $GITCONFIG_SNAPSHOT"
+    else
+      echo "⚠ ~/.gitconfig not readable — worker will use an empty git config." >&2
+      : > "$GITCONFIG_SNAPSHOT"
+    fi
 
     # Render placeholders. Using pipe separators in sed since paths contain /.
     sed -e "s|{{REPO_ROOT}}|$REPO_ROOT|g" \

--- a/scripts/wtf-worker-prompt.md
+++ b/scripts/wtf-worker-prompt.md
@@ -1,0 +1,160 @@
+# Role: WTF worker
+
+You are the autonomous improvement agent for `ambroselittle/agent-skills`. You were invoked by a launchd-scheduled wrapper (`scripts/wtf-worker.sh`). The invocation preamble at the top of this prompt tells you the mode (`new` or `iterate`), the issue or PR number, and the work item's body.
+
+Your job: produce a PR (or update an existing one) that addresses the correction(s). Go end-to-end — classify, edit, test, commit, push, PR, manage labels.
+
+## Environment
+
+- **Working directory:** a fresh `--depth 1` clone of `ambroselittle/agent-skills` under `/tmp/wtf-worker-*`. The wrapper has already `cd`'d into it.
+- **Auth:** `gh` and `git` are authenticated with the user's credentials.
+- **Tools:** full shell + filesystem access; `--dangerously-skip-permissions` is in effect.
+- **Model:** Sonnet.
+
+## Mode: `new`
+
+The issue body is a rolling backlog — one or more correction entries appended over time, separated by `---` lines. Each entry is a markdown block with an `<!-- entry: <filename>.md -->` marker and sections: **User said**, **Context** (branch, session, cwd), **Transcript**, optionally **My take**.
+
+### Step 1 — parse
+
+Split the body at top-level `---` separators. Extract each entry's user message, context, and any transcript hints.
+
+### Step 2 — classify
+
+Pick exactly ONE target per entry:
+
+| # | Category | Where it lands |
+|---|---|---|
+| 1 | **Behavioral guidance** (how Claude should work) | `templates/ambroselittle.md` (user-specific) or `templates/user-claude.md` (universal) — decide by whether the preference is Ambrose-only or anyone-would-benefit |
+| 2 | **Rule** (project-specific directive) | `.claude/rules/<topic>.md` — path-scoped (with `paths:` frontmatter) if it only applies to certain files, unscoped otherwise |
+| 3 | **Skill** (behavior of an existing skill, or a new one) | `skills/<name>/SKILL.md` or supporting files; rarely, a new `skills/<name>/` |
+| 4 | **Hook** (PreToolUse rule) | `hooks/PreToolUse/rules.json` + paired test in `hooks/PreToolUse/tests/rules/` (convention is enforced — see `hooks/PreToolUse/CLAUDE.md`) |
+| 5 | **CLAUDE.md** (repo orientation, structural facts) | `CLAUDE.md` at the repo root. Rare — most things are behavior, not orientation. |
+| 6 | **Upstream repo issue** (correction is about a different repo) | File an issue there: `gh issue create -R <owner>/<repo> --title "..." --body "..."`. No local changes. |
+| 7 | **No-action** (already fixed, one-off, or unactionable) | Close the backlog issue with a comment explaining why. |
+
+Prefer making the smallest reversible change. When in doubt between categories, pick the one with narrower scope (e.g. rule before skill, guidance before rule).
+
+### Step 3 — make the edits
+
+For categories 1–5, edit the relevant file(s) using the tools available. For category 6, file upstream issues. For category 7, no edits.
+
+### Step 4 — verify
+
+- Always: `make test`
+- **Conditionally:** if `git diff --name-only main` includes any path under `skills/create-repo/templates/`, also run `make test-scaffolds TEMPLATE=all`. Otherwise skip (these take ~3min and the CI equivalent has the same path filter — see `.github/workflows/ci.yml`).
+- Formatting/lint: `make check` should be clean.
+
+If tests fail on a change you made, narrow the diff and re-test. If still failing after 2 attempts, stop and comment on the issue with what broke — don't fight it.
+
+### Step 5 — commit + push
+
+One commit per logical entry (or group closely-related entries). Descriptive message — "fix(rule): foo" or "docs(ambroselittle): bar" style. Then:
+
+```bash
+git checkout -b wtf/<issue-N>-<short-slug>
+git push -u origin HEAD
+```
+
+### Step 6 — open the PR
+
+```bash
+gh pr create \
+  --title "wtf(#<N>): <short summary>" \
+  --label WTF \
+  --assignee @me \
+  --body "..."
+```
+
+PR body structure:
+
+```markdown
+## Summary
+
+Brief paragraph — what was corrected, at a high level.
+
+## Entries addressed
+
+### Entry 1: <short title>
+- **Classification:** <category>
+- **Action:** <what you did, where>
+
+### Entry 2: ...
+
+## Verification
+
+- [x] `make test`
+- [ ] `make test-scaffolds TEMPLATE=all` (skipped — no template changes)
+  — or —
+- [x] `make test-scaffolds TEMPLATE=all`
+
+Closes #<issue-N>
+```
+
+Use `Closes #<N>` so the merge auto-closes the backlog issue.
+
+### Step 7 — label management
+
+| Outcome | Action |
+|---|---|
+| **All entries processed, PR opened** | Leave `In Progress` on the issue. Merge of the PR will close the issue; labels become moot. |
+| **Partial success** (some entries done, others failed) | Open the PR with the done entries. Comment on the issue listing the failed ones. Remove `In Progress` from the issue so the remaining entries re-queue: `gh issue edit <N> --remove-label "In Progress"`. The PR should NOT use `Closes #<N>` in this case — use `Refs #<N>` instead. |
+| **No-action only** (category 7 for all entries) | Close the issue: `gh issue close <N> --comment "..."`. No PR. |
+| **Upstream-only** | File upstream issues, then close this repo's issue with a comment linking them. No local PR. |
+
+## Mode: `iterate`
+
+You're revisiting an open PR that a human reviewer marked `CHANGES_REQUESTED`. The wrapper already checked out the PR's head branch.
+
+### Step 1 — read the feedback
+
+```bash
+gh pr view <pr-number> --json reviews,comments,files
+```
+
+Focus on the most recent `CHANGES_REQUESTED` review and any inline comments. Older reviews may have already been addressed. Inline comments (per-line review comments) are `gh api repos/<owner>/<repo>/pulls/<pr>/comments`.
+
+### Step 2 — address the feedback
+
+Edit the code. Don't just respond in comments. Fix what they asked for. If a request is genuinely off-base (would break things, contradicts other reviewer input, or is unclear), respond with a comment explaining the tradeoff — but that's a rare case.
+
+### Step 3 — verify
+
+Same as new-work Step 4: `make test` always, scaffold E2E only when templates changed.
+
+### Step 4 — commit + push
+
+Commit message pattern: `review: address <what>`. Push to the same branch. No new branch, no new PR.
+
+### Step 5 — re-request review + drop claim
+
+```bash
+gh pr comment <pr-number> --body "Addressed the review feedback. Re-requesting review."
+gh pr edit <pr-number> --remove-label "In Progress"
+```
+
+The `In Progress` removal re-opens the PR for the next worker wake in case the reviewer comes back with another round.
+
+## Guardrails
+
+- **Scope:** work only in the checkout. Don't modify other files, other repos, or system state.
+- **No destructive git:** never `--force`, `--no-verify`, `reset --hard`, or `checkout -- .`. If something goes sideways, commit what you have and stop.
+- **No silent skips:** if you can't do something an entry asks, log it explicitly (comment on the issue/PR). Silent failure is worse than visible failure.
+- **Verify before push:** `make test` must pass before `git push`. No exceptions.
+- **Secrets:** if an entry mentions credentials, API keys, or `.env` values, do not include them in commits or PR bodies.
+
+## Output
+
+At the very end, emit a single status line so the wrapper can parse it:
+
+```
+WTF-WORKER-STATUS: <status>
+```
+
+Where `<status>` is one of:
+
+- `completed-pr-<N>` — all entries addressed, PR N opened (new) or updated (iterate)
+- `partial-pr-<N>` — PR N opened with a subset; issue left open with remaining entries
+- `upstream-only` — filed upstream issue(s); local issue closed
+- `no-action` — no changes needed; issue closed with explanation
+- `failed` — could not complete; commented on issue/PR with details

--- a/scripts/wtf-worker.sh
+++ b/scripts/wtf-worker.sh
@@ -1,0 +1,231 @@
+#!/bin/bash
+# Autonomous worker for the /wtf correction backlog.
+#
+# Runs on a launchd schedule. Looks for actionable work:
+#   1) A WTF-labeled open issue without an "In Progress" label → new-work mode
+#   2) A WTF-labeled open PR in CHANGES_REQUESTED review state without
+#      "In Progress" → iterate mode
+#
+# When it finds work, it claims the item by adding "In Progress",
+# shallow-clones ambroselittle/agent-skills to /tmp/, and hands off to
+# `claude -p` with scripts/wtf-worker-prompt.md prepended to an invocation
+# header describing the work item. The Claude session does the actual
+# classification, edits, tests, push, and PR creation/update.
+#
+# Usage: wtf-worker.sh [--dry-run]
+#
+# --dry-run: find work and print the planned action without claiming,
+#            cloning, or invoking Claude. Useful for smoke-testing and
+#            launchd verification.
+
+set -euo pipefail
+
+REPO="ambroselittle/agent-skills"
+LOG_DIR="$HOME/Library/Logs"
+LOG_FILE="$LOG_DIR/wtf-worker.log"
+LOCK_DIR="$HOME/.agent-skills/.wtf-worker.lock.d"
+STALE_LOCK_MINUTES=60
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROMPT_FILE="$SCRIPT_DIR/wtf-worker-prompt.md"
+
+DRY_RUN=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    --help|-h)
+      sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown flag: $arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+mkdir -p "$LOG_DIR" "$HOME/.agent-skills"
+
+log() {
+  printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" | tee -a "$LOG_FILE" >&2
+}
+
+# Lockdir acquisition with stale cleanup. `mkdir` is atomic on POSIX — if
+# two workers race, only one succeeds. If an old lockdir exceeds the stale
+# threshold, we reclaim it (previous worker presumably died).
+if [ -d "$LOCK_DIR" ]; then
+  if find "$LOCK_DIR" -maxdepth 0 -mmin +$STALE_LOCK_MINUTES 2>/dev/null | read -r; then
+    log "stale lockdir detected (>${STALE_LOCK_MINUTES}min), reclaiming"
+    rmdir "$LOCK_DIR" 2>/dev/null || rm -rf "$LOCK_DIR"
+  else
+    log "lockdir held by another worker, exiting"
+    exit 0
+  fi
+fi
+
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  log "failed to acquire lockdir (race with another worker), exiting"
+  exit 0
+fi
+
+# Cleanup trap: clear the lockdir, nuke the clone, and drop the claim if
+# the worker exits abnormally while holding a work item.
+CLONE_DIR=""
+WORK_TYPE=""
+WORK_NUM=""
+CLAIMED=0
+
+cleanup() {
+  local rc=$?
+  if [ -n "$CLONE_DIR" ] && [ -d "$CLONE_DIR" ]; then
+    rm -rf "$CLONE_DIR"
+  fi
+  rmdir "$LOCK_DIR" 2>/dev/null || true
+  if [ "$rc" -ne 0 ] && [ "$CLAIMED" -eq 1 ]; then
+    log "worker failed (rc=$rc), dropping claim on $WORK_TYPE #$WORK_NUM"
+    gh "$WORK_TYPE" edit "$WORK_NUM" -R "$REPO" --remove-label "In Progress" \
+      >/dev/null 2>&1 || true
+    local tail_log
+    tail_log=$(tail -20 "$LOG_FILE" 2>/dev/null | sed 's/`/\\`/g')
+    gh "$WORK_TYPE" comment "$WORK_NUM" -R "$REPO" \
+      --body "Worker failed (rc=$rc). Tail of log:
+
+\`\`\`
+$tail_log
+\`\`\`" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+# 3-attempt retry for transient gh failures. Increasing backoff.
+gh_retry() {
+  local max=3
+  local attempt=1
+  while true; do
+    if "$@"; then return 0; fi
+    if [ "$attempt" -ge "$max" ]; then return 1; fi
+    log "gh call failed, retry $attempt/$max"
+    sleep $((attempt * 2))
+    attempt=$((attempt + 1))
+  done
+}
+
+log "worker starting (dry-run=$DRY_RUN)"
+
+# ----- Phase 1: find work -----
+
+MODE=""
+work_url=""
+work_body=""
+work_head=""
+
+new_work=$(gh_retry gh issue list \
+  -R "$REPO" \
+  --state open \
+  --label WTF \
+  --search '-label:"In Progress"' \
+  --json number,url,body \
+  --limit 1)
+
+if [ "$(printf '%s' "$new_work" | jq 'length')" -gt 0 ]; then
+  WORK_TYPE="issue"
+  WORK_NUM=$(printf '%s' "$new_work" | jq -r '.[0].number')
+  work_url=$(printf '%s' "$new_work" | jq -r '.[0].url')
+  work_body=$(printf '%s' "$new_work" | jq -r '.[0].body')
+  MODE="new"
+else
+  iter_work=$(gh_retry gh pr list \
+    -R "$REPO" \
+    --state open \
+    --label WTF \
+    --search 'review:changes-requested -label:"In Progress"' \
+    --json number,url,body,headRefName \
+    --limit 1)
+
+  if [ "$(printf '%s' "$iter_work" | jq 'length')" -gt 0 ]; then
+    WORK_TYPE="pr"
+    WORK_NUM=$(printf '%s' "$iter_work" | jq -r '.[0].number')
+    work_url=$(printf '%s' "$iter_work" | jq -r '.[0].url')
+    work_body=$(printf '%s' "$iter_work" | jq -r '.[0].body')
+    work_head=$(printf '%s' "$iter_work" | jq -r '.[0].headRefName')
+    MODE="iterate"
+  else
+    log "no work found, exiting cleanly"
+    exit 0
+  fi
+fi
+
+log "found work: $WORK_TYPE #$WORK_NUM ($MODE) — $work_url"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  log "DRY RUN — would claim, clone, and invoke claude"
+  log "  mode: $MODE"
+  if [ -n "$work_head" ]; then
+    log "  head branch: $work_head"
+  fi
+  log "  body preview (first 20 lines):"
+  printf '%s\n' "$work_body" | head -20 | sed 's/^/    | /' | tee -a "$LOG_FILE" >&2
+  exit 0
+fi
+
+# ----- Phase 2: claim -----
+
+log "claiming $WORK_TYPE #$WORK_NUM with 'In Progress' label"
+gh_retry gh "$WORK_TYPE" edit "$WORK_NUM" -R "$REPO" --add-label "In Progress" >/dev/null
+CLAIMED=1
+
+# ----- Phase 3: shallow clone -----
+
+CLONE_DIR="/tmp/wtf-worker-${WORK_NUM}-$(date -u +%Y%m%dT%H%M%SZ)"
+log "cloning $REPO to $CLONE_DIR (--depth 1)"
+git clone --depth 1 "git@github.com:$REPO.git" "$CLONE_DIR" 2>&1 | tee -a "$LOG_FILE" >&2
+
+if [ "$MODE" = "iterate" ]; then
+  cd "$CLONE_DIR"
+  log "fetching PR head branch: $work_head"
+  git fetch --depth 1 origin "$work_head":"$work_head" 2>&1 | tee -a "$LOG_FILE" >&2
+  git checkout "$work_head"
+fi
+
+# ----- Phase 4: build prompt + invoke claude -----
+
+if [ ! -f "$PROMPT_FILE" ]; then
+  log "ERROR: prompt template not found at $PROMPT_FILE"
+  exit 1
+fi
+
+# Assemble prompt: invocation-specific context preamble, then the template
+# contents verbatim. Using printf rather than a heredoc avoids expansion
+# surprises on the template body.
+prompt=$(
+  printf '# WTF worker invocation\n\n'
+  printf -- '- **Mode:** %s\n' "$MODE"
+  printf -- '- **Type:** %s\n' "$WORK_TYPE"
+  printf -- '- **Number:** #%s\n' "$WORK_NUM"
+  printf -- '- **URL:** %s\n' "$work_url"
+  if [ -n "$work_head" ]; then
+    printf -- '- **Head branch:** %s\n' "$work_head"
+  fi
+  printf '\n## Body of the %s\n\n' "$WORK_TYPE"
+  printf '```\n%s\n```\n\n' "$work_body"
+  printf -- '---\n\n'
+  cat "$PROMPT_FILE"
+)
+
+log "invoking claude for $WORK_TYPE #$WORK_NUM"
+cd "$CLONE_DIR"
+
+# Claude handles all label management after this point (per the prompt):
+#   - On success: leaves labels as the PR lifecycle dictates
+#   - On partial success or no-action: removes "In Progress" and comments
+#   - On iterate success: removes "In Progress" from the PR
+# If claude -p itself fails, the trap removes "In Progress" as a fallback.
+if ! claude -p "$prompt" \
+     --model sonnet \
+     --dangerously-skip-permissions \
+     --no-session-persistence \
+     2>&1 | tee -a "$LOG_FILE" >&2; then
+  log "claude -p invocation returned non-zero"
+  exit 1
+fi
+
+log "worker completed $WORK_TYPE #$WORK_NUM"

--- a/scripts/wtf-worker.sh
+++ b/scripts/wtf-worker.sh
@@ -176,8 +176,18 @@ CLAIMED=1
 # ----- Phase 3: shallow clone -----
 
 CLONE_DIR="/tmp/wtf-worker-${WORK_NUM}-$(date -u +%Y%m%dT%H%M%SZ)"
-log "cloning $REPO to $CLONE_DIR (--depth 1)"
-git clone --depth 1 "git@github.com:$REPO.git" "$CLONE_DIR" 2>&1 | tee -a "$LOG_FILE" >&2
+log "cloning $REPO to $CLONE_DIR (--depth 1, HTTPS)"
+
+# HTTPS for the throwaway clone + gh as credential helper for push/fetch
+# from inside the clone. Rationale: launchd's sandbox can't reach the
+# 1Password SSH agent socket, so SSH auth fails. Using HTTPS with gh's
+# credential helper keeps auth off the disk (no token in URLs or config)
+# while letting the worker clone/push autonomously. This protocol choice
+# applies ONLY to this disposable /tmp/ clone — it does not alter any
+# real repo's origin.
+git clone --depth 1 \
+  --config "credential.helper=!gh auth git-credential" \
+  "https://github.com/$REPO.git" "$CLONE_DIR" 2>&1 | tee -a "$LOG_FILE" >&2
 
 if [ "$MODE" = "iterate" ]; then
   cd "$CLONE_DIR"

--- a/setup.sh
+++ b/setup.sh
@@ -5,7 +5,11 @@
 
 set -euo pipefail
 
-clear
+# Only clear when invoked without flags (the default full setup).
+# Subcommands like --install-wtf-worker or --help shouldn't wipe terminal scrollback.
+if [ $# -eq 0 ]; then
+  clear
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLAUDE_DIR="$HOME/.claude"
@@ -13,6 +17,42 @@ CLAUDE_SKILLS_DIR="$CLAUDE_DIR/skills"
 CLAUDE_SETTINGS="$CLAUDE_DIR/settings.json"
 CLAUDE_MD="$CLAUDE_DIR/CLAUDE.md"
 HOOKS_DIR="$CLAUDE_DIR/hooks"
+
+# --------------------------------------------------------------------------- #
+# Subcommands — opt-in side installs that short-circuit the normal setup     #
+# --------------------------------------------------------------------------- #
+
+case "${1:-}" in
+  --install-wtf-worker)
+    exec "$SCRIPT_DIR/scripts/wtf-worker-install.sh" install "${2:-}"
+    ;;
+  --uninstall-wtf-worker)
+    exec "$SCRIPT_DIR/scripts/wtf-worker-install.sh" uninstall
+    ;;
+  --help|-h)
+    cat <<USAGE
+Usage: setup.sh [flag]
+
+Default (no flags): idempotent setup — links skills, installs hooks,
+merges permissions, registers MCP servers, and updates CLAUDE.md.
+
+Flags:
+  --install-wtf-worker [--test]    Install the WTF worker launchd job.
+                                   --test fires an immediate run and
+                                   tails the log.
+  --uninstall-wtf-worker           Uninstall the WTF worker launchd job.
+  --help, -h                       Show this message.
+USAGE
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    printf "Unknown flag: %s\n" "$1" >&2
+    printf "Run 'bash setup.sh --help' for usage.\n" >&2
+    exit 1
+    ;;
+esac
 
 # --------------------------------------------------------------------------- #
 # UX helpers                                                                  #

--- a/skills/wtf/README.md
+++ b/skills/wtf/README.md
@@ -24,10 +24,37 @@ The skill returns almost immediately:
 
 The autonomous worker (see `scripts/wtf-worker.sh` once phase 2 lands) wakes up on a launchd schedule, drains the backlog, classifies each correction (behavioral guidance / rule / skill / hook / CLAUDE.md / upstream issue / no-action), and opens PRs against this repo. You review, request changes if needed, and the worker iterates on the next wake.
 
-Install the worker once phase 3 lands:
+Labels are self-bootstrapping — first `/wtf` invocation creates the `WTF` and `In Progress` labels on the repo if they don't exist.
+
+## Installing the worker
+
+The worker runs on a launchd schedule (every 2 hours, 9am–11pm local). Install it:
 
 ```bash
-bash setup.sh --install-wtf-worker
+bash setup.sh --install-wtf-worker           # install and load
+bash setup.sh --install-wtf-worker --test    # install, then fire an immediate smoke test
+bash setup.sh --uninstall-wtf-worker         # unload and remove
 ```
 
-Labels are self-bootstrapping — first `/wtf` invocation creates the `WTF` and `In Progress` labels on the repo if they don't exist.
+Both commands are idempotent. Re-running install is a clean reload; uninstall is a no-op when nothing's installed.
+
+### What the installer does
+
+- Renders `templates/wtf-worker.plist.template` → `~/Library/LaunchAgents/com.ambroselittle.wtf-worker.plist` (with `{{REPO_ROOT}}` and `{{HOME}}` substituted).
+- Snapshots your `~/.gitconfig` to `~/.agent-skills/wtf-worker.gitconfig`. Necessary because launchd's sandbox can't read iCloud-synced paths, and a common pattern is to symlink dotfiles into iCloud. The plist points `GIT_CONFIG_GLOBAL` at the snapshot.
+- Loads the job with `launchctl load`.
+
+### Monitoring
+
+| Command | What it shows |
+|---|---|
+| `launchctl list \| grep wtf-worker` | PID (or `-`), last exit code, label. If the label isn't there, the job isn't loaded. |
+| `tail -f ~/Library/Logs/wtf-worker.log` | The worker's own timestamped log — what it's doing, what it found, what it's claiming |
+| `tail -f ~/Library/Logs/wtf-worker.out.log` | Raw stdout from launchd invocations |
+| `tail -f ~/Library/Logs/wtf-worker.err.log` | Raw stderr from launchd invocations (git/gh/claude) |
+| `launchctl start com.ambroselittle.wtf-worker` | Manual fire — runs immediately without waiting for the next scheduled tick |
+| `scripts/wtf-worker.sh --dry-run` | From the repo root: find work and print the planned action without claiming, cloning, or invoking claude |
+
+### Repo clones
+
+The worker uses **HTTPS over `gh` credential helper** for its `/tmp/` clones — not SSH — because launchd's sandbox can't reach the 1Password SSH agent socket on this user's machine. This applies only to the disposable worker clones; no real repo's `origin` is affected.

--- a/templates/wtf-worker.plist.template
+++ b/templates/wtf-worker.plist.template
@@ -23,6 +23,12 @@
     <string>{{HOME}}</string>
     <key>PATH</key>
     <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:{{HOME}}/.local/bin</string>
+    <!-- macOS TCC blocks launchd from iCloud-synced paths, which breaks
+         users whose ~/.gitconfig is a symlink into ~/Library/Mobile Documents.
+         The installer snapshots the resolved gitconfig into a launchd-readable
+         location and points GIT_CONFIG_GLOBAL here. -->
+    <key>GIT_CONFIG_GLOBAL</key>
+    <string>{{HOME}}/.agent-skills/wtf-worker.gitconfig</string>
   </dict>
 
   <!--

--- a/templates/wtf-worker.plist.template
+++ b/templates/wtf-worker.plist.template
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  launchd job for the WTF worker. Installed/uninstalled via
+  `bash setup.sh --install-wtf-worker` / `--uninstall-wtf-worker`, which
+  substitutes {{REPO_ROOT}} and {{HOME}} and copies the result to
+  ~/Library/LaunchAgents/com.ambroselittle.wtf-worker.plist.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.ambroselittle.wtf-worker</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>{{REPO_ROOT}}/scripts/wtf-worker.sh</string>
+  </array>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>{{HOME}}</string>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:{{HOME}}/.local/bin</string>
+  </dict>
+
+  <!--
+    Runs every 2 hours between 9am and 11pm local time (8 fires/day).
+    launchd queues missed fires when the Mac is asleep and runs them on wake.
+  -->
+  <key>StartCalendarInterval</key>
+  <array>
+    <dict><key>Hour</key><integer>9</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Hour</key><integer>11</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Hour</key><integer>13</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Hour</key><integer>15</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Hour</key><integer>17</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Hour</key><integer>19</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Hour</key><integer>21</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Hour</key><integer>23</integer><key>Minute</key><integer>0</integer></dict>
+  </array>
+
+  <!-- launchd writes raw stdout/stderr here; the worker script also logs to
+       its own file at ~/Library/Logs/wtf-worker.log. -->
+  <key>StandardOutPath</key>
+  <string>{{HOME}}/Library/Logs/wtf-worker.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>{{HOME}}/Library/Logs/wtf-worker.err.log</string>
+
+  <!-- Don't fire at load — only on the scheduled intervals. Use
+       `launchctl start com.ambroselittle.wtf-worker` for a manual smoke test. -->
+  <key>RunAtLoad</key>
+  <false/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Ships the launchd install story for the `/wtf` worker: plist template, installer, `setup.sh --install-wtf-worker` / `--uninstall-wtf-worker` flags, and the fixes that made the worker actually run under launchd (not just from an interactive shell).

Depends on #35 (phase 2). Base branch is phase 2; rebase to main once #35 lands.

## Autonomous loop closed end-to-end

The worker drained its first real correction during verification of this PR. Issue #34 — "having to approve rsync.. maybe we can add to the allowed pretooluse hook" — was captured via `/wtf` in another session. Phase 2's worker + this phase's launchd install found it, classified as category 4 (Hook), added `Bash(rsync *)` to `hooks/PreToolUse/built-in-rules.json`, wrote two regression tests, pushed the branch, and opened PR #36. Full autonomous round-trip from `/wtf` → backlog → classifier → PR.

## Key decisions

- **HTTPS for the worker's `/tmp/` clones, not SSH.** Under launchd, the sandbox can't reach the 1Password SSH agent socket (IdentityAgent points into the 1Password group container, which is TCC-gated). Per the "don't work around SSH auth failures" rule, we paused and discussed — and chose HTTPS because (a) the clone is disposable, (b) no real repo's `origin` is touched, and (c) `gh auth git-credential` handles auth off-disk without embedding tokens anywhere. See commit `1c0e59e`.
- **Snapshot `~/.gitconfig` at install time.** Users commonly symlink their gitconfig into iCloud Drive (`~/Library/Mobile Documents/...`), and launchd's TCC blocks access there. The installer resolves the symlink while running in the user session (where TCC is fine) and writes a plain-file copy to `~/.agent-skills/wtf-worker.gitconfig`. The plist points `GIT_CONFIG_GLOBAL` at the snapshot. See commit `0aee9b0`.
- **`StartCalendarInterval` every 2h from 9am–11pm local** (8 fires/day). Your chosen cadence — WTF corrections aren't time-sensitive, and sparse scheduling makes the lockdir concurrency guard mostly theoretical.
- **Install is opt-in via `setup.sh --install-wtf-worker`.** Default `bash setup.sh` behavior unchanged — colleagues/other-machines cloning the repo don't get surprise launchd jobs.
- **`RunAtLoad=false`.** Installing doesn't immediately fire the worker. Use `--test` (or `launchctl start com.ambroselittle.wtf-worker`) for an explicit smoke test.

## Verification

### Setup / CI / Infra
- [x] `bash setup.sh --install-wtf-worker --test` installs plist, fires an immediate run, tails the log — verified worker fetched issue #34, cloned, invoked `claude -p`, and produced PR #36
- [x] `bash setup.sh --uninstall-wtf-worker` cleanly unloads and removes (verified between install iterations)
- [x] Re-running install is idempotent (unload-then-load pattern)
- [x] `bash setup.sh` (no flags) still runs the full default setup unchanged
- [x] `make test` — 449 hook-engine + 154 create-repo tests passing

### Skills
- [x] End-to-end autonomous loop verified: `/wtf` capture → backlog append → worker detect → classify → edit → commit → push → PR (#36)

## Known limitations (candidate follow-ups)

- **No iterate-mode dogfood yet.** Exercised `mode: new` but not `mode: iterate`. Will fire when you request changes on a real worker PR.
- **TCC + iCloud is ongoing.** We fixed gitconfig by snapshotting at install. If the worker later needs other TCC-gated paths (e.g. `~/.ssh/config`, `.env` files under iCloud), we'll need similar pattern or a Full Disk Access grant. Won't hit it until it happens.
- **Branch checkouts affect local worker behavior before merge.** The installed plist points at the checkout on this workstation. Switching branches changes what the worker runs until this PR merges to main.

## Phase 4 (separate, post-merge)

Dogfood tuning. Two real corrections across different classifier categories, iterate on the prompt based on observed behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)