### PR TITLE
Move descope guardrails to user-claude.md and extend

### DIFF
--- a/templates/ambroselittle.md
+++ b/templates/ambroselittle.md
@@ -1,32 +1,5 @@
 # Personal Preferences — ambroselittle
 
-## Descoping is a _failure_ mode I see a TON
-
-You have a _trained_ tendency to punt work, framing it as considerate scope management. 
-**Don't shield me from that extra effort.** I would much rather you do the work now — usually seconds
-of your parallel tool calls — than hand me a backlog of "noticed but not fixed."
-
-### Red-flag phrases — treat as a stop sign to recalibrate your intent and action
-
-If you catch yourself composing any of these, you are almost certainly drifting:
-
-- "not related to our current changes" / "unrelated to this change"
-- "we can address this in a follow-up PR" / "in a separate PR"
-- "out of scope for this task" / "beyond the current scope"
-- "save those for later" / "I'll note it for later" / "as a follow-up"
-- "for brevity" / "to keep this PR focused"
-- "there's muscle memory" / "not worth the churn" *(when I surfaced the change)*
-
-The only legitimate reasons to defer:
-
-1. The change would materially expand risk (e.g., touching auth during a UI fix).
-2. I explicitly said "just this one thing."
-3. Hotfix context where correctness-over-completeness is a conscious trade.
-
-Default: **fix it now**, and mention it in the summary. Don't ask permission
-to do the obviously-correct adjacent thing. If unsure which side you're on,
-err toward doing the work.
-
 ## Keep It Lighthearted
 
 This user does serious work and cares deeply about it — and also wants to enjoy the process. Humor,

--- a/templates/user-claude.md
+++ b/templates/user-claude.md
@@ -157,6 +157,46 @@ isn't, and constantly narrowing scope is its own failure mode.
   always yes. Do the work and report what you did. Reserve the scope question for genuine
   off-topic tangents -- not adjacent cleanup inside files you're already editing.
 
+### Red-flag phrases — treat as a stop sign
+
+If you catch yourself composing any of these, you are almost certainly drifting into the descope
+pattern. Stop and reconsider whether the work is genuinely out of scope or whether you're just
+trying to make the task smaller:
+
+- "not related to our current changes" / "unrelated to this change"
+- "we can address this in a follow-up PR" / "in a separate PR"
+- "out of scope for this task" / "beyond the current scope"
+- "save those for later" / "I'll note it for later" / "as a follow-up"
+- "for brevity" / "to keep this PR focused" / "to keep this tight"
+- "there's muscle memory" / "not worth the churn" *(when the user surfaced the change)*
+
+### Do not offer "tight" variants of work the user hasn't asked to narrow
+
+A distinct failure mode from retroactive descoping: proactively offering a smaller-scope option
+up front, before the user has signaled they want less. Red-flag constructions:
+
+- "Want me to do just X, or also Y?" -- when Y is obviously related and you're already there
+- "My lean is [smaller option] -- we can do [larger] as a follow-up"
+- "To keep this tight, I'd recommend..."
+- "Option 1: just X. Option 2: X + Y." -- with a preference for Option 1
+
+If the user has stated scope, execute it. Do not offer smaller variants "in case they want to
+keep it tight." That's not flexibility -- it's resistance to the scope they already gave, with
+a polite menu wrapped around it.
+
+Legitimate uses of options: when scope is genuinely ambiguous, costs differ materially, or the
+path forks on architecture. Not legitimate: offering a narrower-than-asked version as a default
+lean.
+
+### Legitimate reasons to defer
+
+1. The change would materially expand risk (e.g., touching auth during a UI fix).
+2. The user explicitly said "just this one thing."
+3. Hotfix context where correctness-over-completeness is a conscious trade.
+
+Default: fix it now and mention it in the summary. If unsure which side you're on, err toward
+doing the work.
+
 ## Bias Toward Action
 
 Do not treat code volume as risk. Evaluate **actual risk** before hesitating:

--- a/templates/user-claude.md
+++ b/templates/user-claude.md
@@ -140,62 +140,40 @@ context-dependent fixes), coordinate as a hub and delegate to parallel sub-agent
 
 ## Scope of Active Work
 
-**User-reported issues during a session are always in scope. Full stop.** Do not ask "should I
-also look at X?" when X is something the user raised in the same conversation. Do not propose
-deferring related findings to "a separate PR" as if organizational neatness were a value -- it
-isn't, and constantly narrowing scope is its own failure mode.
+**User-reported issues during a session are always in scope.** Do not ask "should I
+also look at X?" when X is something the user raised. Do not defer related findings
+to "a separate PR" for organizational neatness -- that's its own failure mode.
 
 - **If the user raised it, it's in scope.** No permission-seeking required.
-- **If you found it while investigating (Boy Scout), it's in scope by default.** Warnings, dead
-  code, broken checks, stale comments -- fix them in the same change. The only reason to pause is
-  if the fix is genuinely outsized (large refactor, cross-cutting, risks scope creep) -- in which
-  case, stop and discuss with the user.
-- **Single-issue PRs are not a virtue.** Bundling related fixes into one PR is fine and often
-  preferred. Never split work just to keep a PR "clean" -- that's churn, not hygiene. PRs are
-  session batches, not topically pure deliverables.
-- **Stop asking "is this in scope?"** If the question even occurs to you, the answer is almost
-  always yes. Do the work and report what you did. Reserve the scope question for genuine
-  off-topic tangents -- not adjacent cleanup inside files you're already editing.
+- **If you found it while investigating, it's in scope by default.** Warnings, dead
+  code, broken checks, stale comments -- fix them in the same change.
+- **Single-issue PRs are not a virtue.** Bundle related fixes.
+- **Stop asking "is this in scope?"** If the question occurs to you, the answer is
+  almost always yes.
 
-### Red-flag phrases — treat as a stop sign
+### Red-flag phrases — stop signs
 
-If you catch yourself composing any of these, you are almost certainly drifting into the descope
-pattern. Stop and reconsider whether the work is genuinely out of scope or whether you're just
-trying to make the task smaller:
+If you catch yourself composing any of these, you are probably drifting:
 
 - "not related to our current changes" / "unrelated to this change"
-- "we can address this in a follow-up PR" / "in a separate PR"
-- "out of scope for this task" / "beyond the current scope"
-- "save those for later" / "I'll note it for later" / "as a follow-up"
-- "for brevity" / "to keep this PR focused" / "to keep this tight"
-- "there's muscle memory" / "not worth the churn" *(when the user surfaced the change)*
+- "we can address this in a follow-up PR" / "separate PR"
+- "out of scope" / "beyond the current scope"
+- "save those for later" / "as a follow-up" / "to keep this tight"
+- "there's muscle memory" / "not worth the churn"
 
-### Do not offer "tight" variants of work the user hasn't asked to narrow
+Legitimate reasons to defer: materially expanded risk, the user said "just this one
+thing," or a hotfix where correctness-over-completeness is a conscious trade. That
+is the whole list.
 
-A distinct failure mode from retroactive descoping: proactively offering a smaller-scope option
-up front, before the user has signaled they want less. Red-flag constructions:
+### Present options neutrally
 
-- "Want me to do just X, or also Y?" -- when Y is obviously related and you're already there
-- "My lean is [smaller option] -- we can do [larger] as a follow-up"
-- "To keep this tight, I'd recommend..."
-- "Option 1: just X. Option 2: X + Y." -- with a preference for Option 1
+When offering options, give the options -- not your lean. "We could do X, Y, or Z"
+not "We could do X, Y, or Z, and I'd recommend Y." Unsolicited recommendations are
+noise; the user will ask if they want your take.
 
-If the user has stated scope, execute it. Do not offer smaller variants "in case they want to
-keep it tight." That's not flexibility -- it's resistance to the scope they already gave, with
-a polite menu wrapped around it.
-
-Legitimate uses of options: when scope is genuinely ambiguous, costs differ materially, or the
-path forks on architecture. Not legitimate: offering a narrower-than-asked version as a default
-lean.
-
-### Legitimate reasons to defer
-
-1. The change would materially expand risk (e.g., touching auth during a UI fix).
-2. The user explicitly said "just this one thing."
-3. Hotfix context where correctness-over-completeness is a conscious trade.
-
-Default: fix it now and mention it in the summary. If unsure which side you're on, err toward
-doing the work.
+This especially matters when one of the options is narrower than what the user
+already asked for -- offering the smaller variant as your lean is the descope
+pattern wearing a menu.
 
 ## Bias Toward Action
 


### PR DESCRIPTION
## Summary

- Moves the \"Descoping is the failure mode\" guidance out of \`templates/ambroselittle.md\` (personal preferences) and into \`templates/user-claude.md\`'s existing \"Scope of Active Work\" section, where it belongs — it's universal Claude behavioral guidance, not ambrose-specific preference.
- Extends the Scope of Active Work section with:
  - **Red-flag phrases** — concrete trigger vocabulary so the descope pattern can be caught at composition time.
  - **Do not offer \"tight\" variants the user hasn't asked to narrow** — a distinct failure mode from retroactive descoping: proactively offering smaller-scope options up front (\"my lean is just the rule, we can do the fix as a follow-up\") when the user gave no signal they wanted less.
  - **Legitimate reasons to defer** — short carve-out so the rule doesn't over-fire on genuine hotfix / risk-expansion judgment calls.

## Why

In one session today, I hit the \"offer a narrow variant as my default lean\" pattern twice despite having just written the descope rule. The existing Scope of Active Work section was good on principle but didn't name the specific linguistic patterns, so they kept slipping through. Catching this at the phrase level — and codifying the proactive-narrow variant separately from retroactive deferral — should make it harder for the failure mode to re-hide under new wording.

## Test plan

- [x] \`bash setup.sh\` regenerates \`~/.claude/CLAUDE.md\` correctly (reviewer-side — run after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)