### PR TITLE
feat(hook): allowedBranches override for git push rules

### DIFF
--- a/hooks/PreToolUse/engine/engine.py
+++ b/hooks/PreToolUse/engine/engine.py
@@ -43,6 +43,37 @@ def _get_rule_overrides(config: dict | None, rule_id: str | None) -> dict | None
     return None
 
 
+def _branch_matches_allowed(payload: dict, allowed_branches: list[str]) -> bool:
+    """Check if a git push's target branch matches at least one allowed pattern.
+
+    Mirrors `_path_matches_allowed` but for branch-based rules (git-push-direct,
+    git-force-push). Only applies to Bash tool calls containing a `git push`;
+    returns False for other payloads so the outer deny stands.
+
+    If the push omits a branch (e.g. `git push` with a tracking branch), the
+    branch can't be confirmed, so this returns False — consistent with the
+    git-push-direct matcher's "don't assume the worst" stance.
+    """
+    from fnmatch import fnmatch
+
+    from operations.common import _command, _is_bash, _split_subcommands
+    from operations.git import _extract_push_branch, _is_git_subcommand
+
+    if not _is_bash(payload):
+        return False
+
+    command = _command(payload)
+    for tokens in _split_subcommands(command):
+        if not _is_git_subcommand(tokens, "push"):
+            continue
+        branch = _extract_push_branch(tokens)
+        if branch is None:
+            continue
+        if any(fnmatch(branch, p) for p in allowed_branches):
+            return True
+    return False
+
+
 def _path_matches_allowed(
     payload: dict, allowed_paths: list[str], repo_root: str, cwd: str
 ) -> bool:
@@ -170,9 +201,15 @@ def evaluate(payload: dict, rules: list, repo_root: str | None = None) -> dict:
             # Check for per-repo override
             rule_id = rule_ref.get("id") if rule_ref else None
             overrides = _get_rule_overrides(repo_config, rule_id)
-            if overrides and "allowedPaths" in overrides:
-                if _path_matches_allowed(payload, overrides["allowedPaths"], repo_root or "", cwd):
-                    continue  # Skip this deny — path is allowed by repo config
+            if overrides:
+                if "allowedPaths" in overrides:
+                    if _path_matches_allowed(
+                        payload, overrides["allowedPaths"], repo_root or "", cwd
+                    ):
+                        continue  # Skip this deny — path is allowed by repo config
+                if "allowedBranches" in overrides:
+                    if _branch_matches_allowed(payload, overrides["allowedBranches"]):
+                        continue  # Skip this deny — branch is allowed by repo config
             return {"decision": "deny", "reason": reason}
     for action, reason, _rule_ref in decisions:
         if action == "ask":

--- a/hooks/PreToolUse/tests/test_repo_config_override.py
+++ b/hooks/PreToolUse/tests/test_repo_config_override.py
@@ -20,6 +20,36 @@ def _env_deny_rule():
     }
 
 
+def _push_main_deny_rule():
+    return {
+        "id": "block-push-main",
+        "description": "Block direct push to main or master",
+        "operation": "git-push-direct",
+        "deny-branches": ["main", "master"],
+        "action": "deny",
+        "reason": "Direct push to main/master not permitted — open a PR",
+    }
+
+
+def _force_push_main_deny_rule():
+    return {
+        "id": "block-force-push-main",
+        "description": "Block force push to main or master",
+        "operation": "git-force-push",
+        "deny-branches": ["main", "master"],
+        "action": "deny",
+        "reason": "Force pushing to main/master is not permitted",
+    }
+
+
+def _write_repo_config(repo, rules):
+    config_dir = repo / ".agent-skills"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "config.json").write_text(
+        json.dumps({"hooks": {"PreToolUse": {"rules": rules}}})
+    )
+
+
 def test_override_allows_denied_path(tmp_path):
     """A repo config with allowedPaths should skip the deny for matching paths."""
     _repo_config_cache.clear()
@@ -169,3 +199,128 @@ def test_malformed_config_is_ignored(tmp_path):
     payload = _payload("Read", {"file_path": str(repo / ".env")})
     result = evaluate(payload, [_env_deny_rule()], repo_root=str(repo))
     assert result["decision"] == "deny"
+
+
+# ---------------------------------------------------------------------------
+# allowedBranches override — mirrors allowedPaths but for git push rules
+# ---------------------------------------------------------------------------
+
+
+def test_override_allows_denied_push_to_main(tmp_path):
+    """A repo config with allowedBranches should skip the deny for matching branches."""
+    _repo_config_cache.clear()
+
+    repo = tmp_path / "myrepo"
+    _write_repo_config(
+        repo, [{"rule": "block-push-main", "allowedBranches": ["main"]}]
+    )
+
+    payload = _payload("Bash", {"command": "git push -u origin main"})
+    result = evaluate(payload, [_push_main_deny_rule()], repo_root=str(repo))
+    assert result["decision"] == "proceed"
+
+
+def test_override_allows_force_push_to_main(tmp_path):
+    """allowedBranches should also override the force-push rule."""
+    _repo_config_cache.clear()
+
+    repo = tmp_path / "myrepo"
+    _write_repo_config(
+        repo, [{"rule": "block-force-push-main", "allowedBranches": ["main"]}]
+    )
+
+    payload = _payload("Bash", {"command": "git push --force origin main"})
+    result = evaluate(payload, [_force_push_main_deny_rule()], repo_root=str(repo))
+    assert result["decision"] == "proceed"
+
+
+def test_override_does_not_affect_other_denied_branch(tmp_path):
+    """A push to master should still deny when only main is allowed."""
+    _repo_config_cache.clear()
+
+    repo = tmp_path / "myrepo"
+    _write_repo_config(
+        repo, [{"rule": "block-push-main", "allowedBranches": ["main"]}]
+    )
+
+    payload = _payload("Bash", {"command": "git push origin master"})
+    result = evaluate(payload, [_push_main_deny_rule()], repo_root=str(repo))
+    assert result["decision"] == "deny"
+
+
+def test_override_wildcard_allows_any_branch(tmp_path):
+    """A '*' allowedBranches entry effectively disables the rule for this repo."""
+    _repo_config_cache.clear()
+
+    repo = tmp_path / "myrepo"
+    _write_repo_config(repo, [{"rule": "block-push-main", "allowedBranches": ["*"]}])
+
+    for branch in ["main", "master"]:
+        payload = _payload("Bash", {"command": f"git push origin {branch}"})
+        result = evaluate(payload, [_push_main_deny_rule()], repo_root=str(repo))
+        assert result["decision"] == "proceed", f"expected proceed for {branch}"
+
+
+def test_override_no_branches_specified_still_denies(tmp_path):
+    """Overrides without allowedBranches leave the deny intact."""
+    _repo_config_cache.clear()
+
+    repo = tmp_path / "myrepo"
+    _write_repo_config(repo, [{"rule": "block-push-main"}])
+
+    payload = _payload("Bash", {"command": "git push origin main"})
+    result = evaluate(payload, [_push_main_deny_rule()], repo_root=str(repo))
+    assert result["decision"] == "deny"
+
+
+def test_allowed_branches_with_no_explicit_branch_still_denies(tmp_path):
+    """If the push has no explicit branch, we can't confirm it's allowed — deny stands.
+
+    Only relevant when the deny rule already matched (which requires a known
+    branch). This test pairs with git-push-direct's own "don't assume" logic:
+    `_branch_matches_allowed` returns False for ambiguous pushes so the outer
+    deny proceeds — but in practice the outer deny also requires a known
+    branch, so this is defense in depth.
+    """
+    _repo_config_cache.clear()
+
+    repo = tmp_path / "myrepo"
+    _write_repo_config(
+        repo, [{"rule": "block-push-main", "allowedBranches": ["main"]}]
+    )
+
+    # A push without a branch arg — the deny rule won't match this anyway,
+    # but we want to confirm the override doesn't spuriously proceed.
+    payload = _payload("Bash", {"command": "git push"})
+    result = evaluate(payload, [_push_main_deny_rule()], repo_root=str(repo))
+    assert result["decision"] == "proceed"  # deny didn't match in the first place
+
+
+def test_allowed_paths_and_branches_coexist(tmp_path):
+    """A single repo config may contain both kinds of overrides for different rules."""
+    _repo_config_cache.clear()
+
+    repo = tmp_path / "myrepo"
+    _write_repo_config(
+        repo,
+        [
+            {"rule": "block-env-reads", "allowedPaths": [".eval-runs/**/.env*"]},
+            {"rule": "block-push-main", "allowedBranches": ["main"]},
+        ],
+    )
+
+    read_payload = _payload(
+        "Read", {"file_path": str(repo / ".eval-runs" / "x" / ".env")}
+    )
+    assert (
+        evaluate(read_payload, [_env_deny_rule()], repo_root=str(repo))["decision"]
+        == "proceed"
+    )
+
+    push_payload = _payload("Bash", {"command": "git push origin main"})
+    assert (
+        evaluate(push_payload, [_push_main_deny_rule()], repo_root=str(repo))[
+            "decision"
+        ]
+        == "proceed"
+    )


### PR DESCRIPTION
Mirrors the existing `allowedPaths` mechanism but for the branch-based rules (`block-push-main`, `block-force-push-main`). A repo-local `.agent-skills/config.json` can now opt out of the direct/force-push denies on a per-branch basis:

    {
      "hooks": {
        "PreToolUse": {
          "rules": [
            { "rule": "block-push-main", "allowedBranches": ["main"] }
          ]
        }
      }
    }

Useful for personal repos where the PR dance isn't wanted. `"*"` acts as a blanket opt-out. When a push omits an explicit branch, the override returns False — consistent with the matcher's "don't assume" stance for ambiguous pushes.

## Summary

<!-- What changed and why. Link issues with "Closes #N". -->

## Verification

<!-- Delete sections that don't apply to your changes. -->

### Skills
- [ ] Manually ran the modified skill(s) end-to-end and confirmed expected behavior
- [ ] Tested edge cases (missing args, bad input, partial state)

### Hooks (PreToolUse)
- [ ] Manually triggered the hook rule and confirmed it fires correctly (deny/ask/allow)
- [ ] Confirmed non-matching cases pass through (no false positives)
- [ ] `cd hooks/PreToolUse && uvx pytest tests/ -v` — all passing

### Templates (create-repo)
- [ ] Unit + structural tests: `cd skills/create-repo && uv run pytest tests/ -v -m "not e2e"`
- [ ] Scaffold E2E for affected templates: `make test-scaffolds TEMPLATE=<name>`
- [ ] Scaffold E2E for all templates: `make test-scaffolds TEMPLATE=all`
- [ ] Added or updated tests for new/changed behavior

### Setup / CI / Infra
- [x] Ran `setup.sh` on a clean state and confirmed it completes without errors
- [ ] Verified CI workflow changes with a test push or `act` dry run
