### PR TITLE
feat(setup): add --no-clear flag + CLEAR=0 Makefile pass-through

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ init: ## Install deps, link skills & hooks, sync envs
 	@printf "\033[36mInstalling Playwright browsers...\033[0m\n"
 	@cd skills/deploy-aws && uv run playwright install chromium --quiet 2>/dev/null || true
 	@printf "\033[36mRunning setup...\033[0m\n"
-	@./setup.sh
+	@./setup.sh $(if $(filter 0,$(CLEAR)),--no-clear,)
 	@main_repo=$$(git rev-parse --git-common-dir | sed 's|/\.git$$||'); \
 	if [ "$$main_repo" = "$$(pwd)" ]; then \
 		true; \

--- a/setup.sh
+++ b/setup.sh
@@ -41,9 +41,13 @@ Flags:
                                    --test fires an immediate run and
                                    tails the log.
   --uninstall-wtf-worker           Uninstall the WTF worker launchd job.
+  --no-clear                       Skip the terminal clear at setup start
+                                   (useful when invoked from another script).
   --help, -h                       Show this message.
 USAGE
     exit 0
+    ;;
+  --no-clear)
     ;;
   "")
     ;;


### PR DESCRIPTION
## Summary

When `agent-skills` setup is invoked from a parent bootstrap script (e.g. a new-machine setup that clones agent-skills and runs `make init`), the default terminal `clear` at the start of `setup.sh` wipes the parent script's output — making it hard to see the combined setup flow in one scrollback.

Add a `--no-clear` flag to `setup.sh` and a `CLEAR=0` Makefile parameter that forwards it, so nested invocations can opt out of the clear while direct interactive runs keep the current clean-start behavior.

**Behavior matrix:**

| Invocation | Expands to | Clears? |
|---|---|---|
| `make init` | `./setup.sh` | ✓ (as before) |
| `make init CLEAR=0` | `./setup.sh --no-clear` | ✗ |
| `make init CLEAR=1` | `./setup.sh` | ✓ (CLEAR!=0 is a no-op) |
| `./setup.sh` direct | — | ✓ |
| `./setup.sh --no-clear` | — | ✗ |

## Verification

### Setup / CI / Infra
- [x] `bash -n setup.sh` passes (syntax)
- [x] `make -n init`, `make -n init CLEAR=0`, `make -n init CLEAR=1` expand to the expected `./setup.sh` invocations
- [x] `./setup.sh --no-clear` is accepted by the flag dispatch (doesn't hit the `*)` unknown-flag error branch)
- [ ] End-to-end: will be exercised on next machine setup via parent `~/iCloud/Settings/setup.sh` (which now calls `make init CLEAR=0`)

## Implementation notes

- The `--no-clear` case in `setup.sh`'s flag dispatch is an intentional no-op (`;;`) — the existing `[ $# -eq 0 ]` guard on the clear statement already means any arg skips the clear, so the flag just needs to be *recognized* so the `*)` unknown-flag branch doesn't reject it.
- `$(if $(filter 0,$(CLEAR)),--no-clear,)` in the Makefile only treats `CLEAR=0` as opt-out; all other values (including `CLEAR=1`, unset) produce the normal clearing behavior. This matches the user mental model of "0 means off."

🤖 Generated with [Claude Code](https://claude.com/claude-code)