### PR TITLE
wtf(#47): require tests inline per phase, not deferred to a final phase

### DIFF
--- a/skills/plan-review/agents/testing-strategy.md
+++ b/skills/plan-review/agents/testing-strategy.md
@@ -13,6 +13,8 @@ Your focus is whether the testing approach will actually catch bugs and give con
 
 **Test placement and timing:**
 
+- **Incremental tests check (primary signal):** For each phase that introduces new behavior, look at its task list. Does it include test tasks alongside the implementation tasks? If tests are absent from behavior-introducing phases and only appear in a later "testing" or "add tests" phase, flag this as a MISMATCH — it is the most reliable predictor that tests get cut under time pressure.
+- **Standalone test phase anti-pattern:** A plan that ends with a dedicated phase whose sole purpose is writing tests (e.g., "Phase 4: Write tests", "Phase 3: Add test coverage") is a planning smell. Flag it and recommend folding those test tasks into the phases that introduce the corresponding code.
 - Are tests planned alongside the code they cover, or deferred to a final phase? Deferring all tests to the end is a risk — flag it.
 - For bug fixes: is there a task to write a failing test *before* the fix, to prove the bug exists? If not, suggest it.
 

--- a/skills/plan-work/SKILL.md
+++ b/skills/plan-work/SKILL.md
@@ -237,7 +237,8 @@ Synthesize the issue context and discovery findings into a phased implementation
 Each phase must be:
 - **Committable** — leaves the codebase in a working, verifiable state
 - **Testable** — has a concrete verify step (a test command, a manual check, a specific assertion)
-- **Focused** — one logical concern (data model, API layer, UI, tests, migration, etc.)
+- **Focused** — one logical concern (data model, API layer, UI, migration, etc.)
+- **Self-contained tests** — tests for code introduced in this phase are tasks *within this phase*, not deferred to a later phase. A standalone "write tests" or "add tests" phase at the end of the plan is a red flag — fold those tasks into the phase that introduces the code.
 
 If you're unsure how to phase the work, fewer larger phases beats more smaller ones.
 
@@ -305,4 +306,5 @@ Ask: **"Any changes to the plan before we start?"**
 - **Challenge the issue before following it.** Compare what the issue says against what you actually find. If there's a mismatch — stale assumptions, already-completed work, a changed interface, a better path — surface it and collaborate with the user rather than blindly following the issue.
 - **Propose alternatives when you see them.** If discovery reveals a clearly better approach, raise it. Present tradeoffs, not a verdict. The user decides.
 - **Be specific in tasks.** "Update `src/models/user.ts` to add `darkMode: boolean`" is useful. "Add dark mode support" is not.
+- **Tests belong with the code.** Every phase that introduces behavior must include test tasks for that behavior in the same phase — not in a dedicated "add tests" phase at the end. A paired test task looks like: "test: `createUser` — covers success, duplicate email, validation error." Standalone test phases are a planning smell: tests get cut when time pressure hits.
 - **One open question beats one wrong assumption.** Surface uncertainty rather than resolving it silently.

--- a/skills/plan-work/references/plan-template.md
+++ b/skills/plan-work/references/plan-template.md
@@ -45,7 +45,11 @@ status: planning
 
 **Tasks:**
 - [ ] `<commit message>` — <what this task does; name the files and what changes>
+- [ ] `test: <commit message>` — <tests for the above: which behaviors, success path, failure paths>
 - [ ] `<commit message>` — <what this task does>
+- [ ] `test: <commit message>` — <tests for the above>
+
+Note: test tasks belong *within* the phase that introduces the code, not in a final phase. A standalone "write tests" phase at the end is a planning smell.
 
 **Verify (after all tasks in phase):**
 - [ ] <concrete verify step — test command or manual check>


### PR DESCRIPTION
## Summary

Plans should include test tasks incrementally alongside the code they cover — not deferred to a standalone "add tests" phase at the end. A final-phase-only test approach is a planning smell that leads to tests being cut when time pressure hits.

## Entries addressed

### Entry 1: Incremental tests per plan phase

- **Classification:** Skill (plan-work, plan-review)
- **Action:**
  - `skills/plan-work/SKILL.md`: Added a **Self-contained tests** rule to the Phase structure rules (tests for code in a phase belong *in that phase*, not deferred), and a paired **Tests belong with the code** guideline.
  - `skills/plan-work/references/plan-template.md`: Updated the phase task example to show `test:` tasks paired with implementation tasks, with an explicit note about the anti-pattern.
  - `skills/plan-review/agents/testing-strategy.md`: Strengthened the "test placement and timing" section with two explicit checks: the per-phase incremental test check (primary signal), and the standalone test phase anti-pattern flag (MISMATCH-level finding).

## Verification

- [x] \`make test\` — 612 tests passing (458 hook engine + 154 create-repo)
- [ ] \`make test-scaffolds TEMPLATE=all\` (skipped — no template changes)

Closes #47