### PR TITLE
wtf(#49): update work folder reference and plan-currency guidance in user-claude.md

### DIFF
--- a/templates/user-claude.md
+++ b/templates/user-claude.md
@@ -58,8 +58,8 @@ untrackable dependency on local state that undermines the goal of a repeatable C
 | Project-wide conventions, rules, standards | `<repo>/.claude/rules/<topic>.md` |
 | Project orientation (structure, build, test) | `<repo>/CLAUDE.md` |
 | In-progress work, task breakdown | Tasks tool (current session only) |
-| Implementation plans | `.work/<slug>/plan.md` (gitignored) |
-| Active bug / short-lived project state | Auto-memory is acceptable, but prefer a note in `.work/` |
+| Implementation plans | `<work-folder>/<slug>/plan.md` — work folder is set in `~/.claude/agent-skills.json` (`work_root`) |
+| Active bug / short-lived project state | Auto-memory is acceptable, but prefer a note in your work folder |
 
 **Almost nothing should go into auto-memory.** If it's a pattern, preference, or lesson that should
 survive a `git clone` on a new machine — it belongs in the repo. Run `bash setup.sh` to deploy
@@ -72,11 +72,13 @@ to `~/.agent-skills/research/<topic-slug>.md`. Before researching a topic, check
 exists there — it may already have the answer or save significant effort. Update stale research when
 you discover new information.
 
-## .work/ Plans Are Scaffolding
+## Work Folder Plans
 
-- Gitignore `.work/` directories — do not commit implementation plans
-- PRs are the record of what was done and why (git blame → PR → ticket)
-- The PR creation step (in /do-work) captures key decisions in the PR description
+Plans live outside the repo in your configured work folder (`~/.claude/agent-skills.json` → `work_root`, defaulting to `~/Work`). This keeps them alive across branch deletions and accessible from any repo.
+
+- **Keep plans current as work progresses.** A plan that reflects reality lets any new agent session pick up right where the last one left off — no re-discovery, no surprises about what's done or not. Update phase and task status as you complete them, not just at the end.
+- PRs are the permanent record of *what was done and why* (git blame → PR → ticket). Plans are the *working state* — update them, don't treat them as archival.
+- The PR creation step (in /do-work) captures key decisions in the PR description.
 
 ## Working with git/gh
 


### PR DESCRIPTION
## Summary

Updates `templates/user-claude.md` to reflect the external work folder introduced in PR #44 and to encourage keeping plans current so agent sessions can hand off cleanly without re-discovery.

## Entries addressed

### Entry 1: update-the-user-claude-md-file-so-it-use
- **Classification:** Category 1 — Behavioral guidance (universal)
- **Action:** Two edits to `templates/user-claude.md`:
  1. **Work dir reference** — replaced `.work/<slug>/plan.md (gitignored)` in the persistence table with `<work-folder>/<slug>/plan.md` pointing to the `~/.claude/agent-skills.json` `work_root`; similarly updated the "active bug" row.
  2. **Plan-currency section** — renamed `## .work/ Plans Are Scaffolding` → `## Work Folder Plans`, added explanation of the external folder location, and added explicit guidance to keep plan status current as work progresses so new sessions can resume without re-discovery or surprise.

## Verification

- [x] `make test` (458 hook tests + 154 create-repo tests — all pass)
- [ ] `make test-scaffolds TEMPLATE=all` (skipped — no template scaffold changes)

Closes #49