### PR TITLE
docs: replace .work/ references with configured work folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ dist/
 !.env.example
 
 # Project
-.work/
 .superset/
 install-deps.sh
 .claude/scheduled_tasks.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ GitHub Actions (`.github/workflows/ci.yml`) runs on push to PR branches and main
 make init
 ```
 
-This installs `uv` if missing, syncs Python environments (hooks + create-repo), runs `setup.sh` to link skills and hooks, and copies `.work/` for worktrees. Run it once after cloning, or after switching to a new worktree.
+This installs `uv` if missing, syncs Python environments (hooks + create-repo), and runs `setup.sh` to link skills and hooks. Run it once after cloning, or after switching to a new worktree.
 
 ## setup.sh
 

--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,6 @@ init: ## Install deps, link skills & hooks, sync envs
 	@cd skills/deploy-aws && uv run playwright install chromium --quiet 2>/dev/null || true
 	@printf "\033[36mRunning setup...\033[0m\n"
 	@./setup.sh $(if $(filter 0,$(CLEAR)),--no-clear,)
-	@main_repo=$$(git rev-parse --git-common-dir | sed 's|/\.git$$||'); \
-	if [ "$$main_repo" = "$$(pwd)" ]; then \
-		true; \
-	elif [ -d "$$main_repo/.work" ]; then \
-		rsync -a --delete "$$main_repo/.work/" .work/; \
-		echo "Copied .work/ from $$main_repo"; \
-	fi
 	@$(MAKE) --no-print-directory help
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ These skills form a pipeline from idea to merged PR:
 
 | Skill | What it does |
 | --- | --- |
-| `/plan-work` | Takes a GitHub issue or description, discovers relevant code, and produces a phased implementation plan in `.work/<slug>/plan.md`. Unlike Claude's built-in plans, these persist to disk and survive across sessions. |
+| `/plan-work` | Takes a GitHub issue or description, discovers relevant code, and produces a phased implementation plan in `<work-folder>/<slug>/plan.md` (under your configured `work_root`, defaulting to `~/Work`). Unlike Claude's built-in plans, these persist to disk and survive across sessions and branch deletions. |
 | `/plan-review` | Runs parallel specialized agents (architecture, completeness, security, testing) over the plan before a line of code is written. Presents findings stepwise by category for in-session discussion. Auto-runs for large plans. |
 | `/do-work` | Implements work from a plan end-to-end — coordinates sub-agents, verifies, commits per task, pushes, and opens a PR when done. No confirmation gates; hard stops only for genuine blockers. |
 | `/code-review` | Multi-pass parallel review with specialized agents. Two-pass approach (normal + reversed diff) for higher recall. Presents findings in-session with opt-out model — default is to fix everything. |

--- a/hooks/PreToolUse/tests/rules/test_block-piping-network-content-to-a-shell.py
+++ b/hooks/PreToolUse/tests/rules/test_block-piping-network-content-to-a-shell.py
@@ -52,7 +52,7 @@ def test_boundary_pipe_with_flags(rule):
 
 def test_boundary_bash_script_file_allowed(rule):
     """Running a bash script from disk is NOT matched — no pipe involved."""
-    result = evaluate(_bash("bash .work/tmp/setup.sh"), [rule])
+    result = evaluate(_bash("bash scripts/setup.sh"), [rule])
     assert result["decision"] == "proceed"
 
 

--- a/hooks/PreToolUse/tests/test_repo_config_override.py
+++ b/hooks/PreToolUse/tests/test_repo_config_override.py
@@ -45,9 +45,7 @@ def _force_push_main_deny_rule():
 def _write_repo_config(repo, rules):
     config_dir = repo / ".agent-skills"
     config_dir.mkdir(parents=True, exist_ok=True)
-    (config_dir / "config.json").write_text(
-        json.dumps({"hooks": {"PreToolUse": {"rules": rules}}})
-    )
+    (config_dir / "config.json").write_text(json.dumps({"hooks": {"PreToolUse": {"rules": rules}}}))
 
 
 def test_override_allows_denied_path(tmp_path):
@@ -211,9 +209,7 @@ def test_override_allows_denied_push_to_main(tmp_path):
     _repo_config_cache.clear()
 
     repo = tmp_path / "myrepo"
-    _write_repo_config(
-        repo, [{"rule": "block-push-main", "allowedBranches": ["main"]}]
-    )
+    _write_repo_config(repo, [{"rule": "block-push-main", "allowedBranches": ["main"]}])
 
     payload = _payload("Bash", {"command": "git push -u origin main"})
     result = evaluate(payload, [_push_main_deny_rule()], repo_root=str(repo))
@@ -225,9 +221,7 @@ def test_override_allows_force_push_to_main(tmp_path):
     _repo_config_cache.clear()
 
     repo = tmp_path / "myrepo"
-    _write_repo_config(
-        repo, [{"rule": "block-force-push-main", "allowedBranches": ["main"]}]
-    )
+    _write_repo_config(repo, [{"rule": "block-force-push-main", "allowedBranches": ["main"]}])
 
     payload = _payload("Bash", {"command": "git push --force origin main"})
     result = evaluate(payload, [_force_push_main_deny_rule()], repo_root=str(repo))
@@ -239,9 +233,7 @@ def test_override_does_not_affect_other_denied_branch(tmp_path):
     _repo_config_cache.clear()
 
     repo = tmp_path / "myrepo"
-    _write_repo_config(
-        repo, [{"rule": "block-push-main", "allowedBranches": ["main"]}]
-    )
+    _write_repo_config(repo, [{"rule": "block-push-main", "allowedBranches": ["main"]}])
 
     payload = _payload("Bash", {"command": "git push origin master"})
     result = evaluate(payload, [_push_main_deny_rule()], repo_root=str(repo))
@@ -285,9 +277,7 @@ def test_allowed_branches_with_no_explicit_branch_still_denies(tmp_path):
     _repo_config_cache.clear()
 
     repo = tmp_path / "myrepo"
-    _write_repo_config(
-        repo, [{"rule": "block-push-main", "allowedBranches": ["main"]}]
-    )
+    _write_repo_config(repo, [{"rule": "block-push-main", "allowedBranches": ["main"]}])
 
     # A push without a branch arg — the deny rule won't match this anyway,
     # but we want to confirm the override doesn't spuriously proceed.
@@ -309,18 +299,11 @@ def test_allowed_paths_and_branches_coexist(tmp_path):
         ],
     )
 
-    read_payload = _payload(
-        "Read", {"file_path": str(repo / ".eval-runs" / "x" / ".env")}
-    )
-    assert (
-        evaluate(read_payload, [_env_deny_rule()], repo_root=str(repo))["decision"]
-        == "proceed"
-    )
+    read_payload = _payload("Read", {"file_path": str(repo / ".eval-runs" / "x" / ".env")})
+    assert evaluate(read_payload, [_env_deny_rule()], repo_root=str(repo))["decision"] == "proceed"
 
     push_payload = _payload("Bash", {"command": "git push origin main"})
     assert (
-        evaluate(push_payload, [_push_main_deny_rule()], repo_root=str(repo))[
-            "decision"
-        ]
+        evaluate(push_payload, [_push_main_deny_rule()], repo_root=str(repo))["decision"]
         == "proceed"
     )

--- a/skills/create-repo/SKILL.md
+++ b/skills/create-repo/SKILL.md
@@ -335,7 +335,7 @@ Then report:
 
 ## Step 9: Template Improvement Report
 
-If any fixes were needed during verification (Step 6) — e.g., a dependency version introduced a breaking change that the templates don't account for — write a summary of template changes needed to `.work/create-repo-template-fixes/plan.md` in the agent-skills repo. Include:
+If any fixes were needed during verification (Step 6) — e.g., a dependency version introduced a breaking change that the templates don't account for — write a summary of template changes needed to `<work-folder>/create-repo-template-fixes/plan.md` under your configured `work_root` (from `~/.claude/agent-skills.json`, defaulting to `~/Work`). Include:
 - What broke and why (dependency version change, config format change, etc.)
 - Exact file changes needed in the templates
 - Whether the fix should be deterministic (template/script change) or kept as AI-handled

--- a/templates/user-claude.md
+++ b/templates/user-claude.md
@@ -81,7 +81,7 @@ Before saving anything, apply this test — in order:
    → Yes → Use the Tasks tool or keep it in context. Do not save it at all.
 
 4. **Is this genuinely project-specific AND needed across sessions?**
-   → Auto-memory is acceptable only here, but prefer a `.work/` note.
+   → Auto-memory is acceptable only here, but prefer a note in your configured work folder.
 
 **The litmus test:** if you find yourself writing "in this project" or "for this repo," it's a
 rule or CLAUDE.md entry. If you'd remove that qualifier and it still applies everywhere, it's a


### PR DESCRIPTION
## Summary

The `.work/<slug>/` convention is fully superseded by the configured work folder (`work_root` in `~/.claude/agent-skills.json`, defaulting to `~/Work`). Plans now live outside any repo, so they survive branch deletion and work across worktrees without copying. This PR removes the lingering references and the obsolete copy machinery.

- **Docs** (`CLAUDE.md`, `README.md`, `templates/user-claude.md`, `skills/create-repo/SKILL.md`) — point all plan-location references at `<work-folder>` under the configured `work_root`.
- **`Makefile`** — drop the legacy `.work/` rsync block from `make init` (worktrees no longer need a local plan dir).
- **`.gitignore`** — drop the obsolete `.work/` entry.
- **Hook test** (`test_block-piping-network-content-to-a-shell.py`) — neutralize the illustrative `.work/tmp/setup.sh` path to `scripts/setup.sh`.

Drive-by: `ruff format` applied to `hooks/PreToolUse/tests/test_repo_config_override.py` (pre-existing drift surfaced by `make check`).

## Verification

### Hooks (PreToolUse)
- [x] `cd hooks/PreToolUse && uvx pytest tests/ -v` — 458 passing
- [x] Affected rule test (`test_block-piping-network-content-to-a-shell.py`) — 11 passing with neutralized path

### Templates (create-repo)
- [x] Unit + structural tests: `cd skills/create-repo && uv run pytest tests/ -v -m "not e2e"` — 154 passing

### Setup / CI / Infra
- [x] `make check` — format + lint clean
- [x] `make test` — full unit suite (612 tests) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)