### PR TITLE
feat(skills): /start-work + Linear in-progress + tighter slug rule

### DIFF
--- a/hooks/PreToolUse/tests/test_repo_config_override.py
+++ b/hooks/PreToolUse/tests/test_repo_config_override.py
@@ -45,9 +45,7 @@ def _force_push_main_deny_rule():
 def _write_repo_config(repo, rules):
     config_dir = repo / ".agent-skills"
     config_dir.mkdir(parents=True, exist_ok=True)
-    (config_dir / "config.json").write_text(
-        json.dumps({"hooks": {"PreToolUse": {"rules": rules}}})
-    )
+    (config_dir / "config.json").write_text(json.dumps({"hooks": {"PreToolUse": {"rules": rules}}}))
 
 
 def test_override_allows_denied_path(tmp_path):
@@ -211,9 +209,7 @@ def test_override_allows_denied_push_to_main(tmp_path):
     _repo_config_cache.clear()
 
     repo = tmp_path / "myrepo"
-    _write_repo_config(
-        repo, [{"rule": "block-push-main", "allowedBranches": ["main"]}]
-    )
+    _write_repo_config(repo, [{"rule": "block-push-main", "allowedBranches": ["main"]}])
 
     payload = _payload("Bash", {"command": "git push -u origin main"})
     result = evaluate(payload, [_push_main_deny_rule()], repo_root=str(repo))
@@ -225,9 +221,7 @@ def test_override_allows_force_push_to_main(tmp_path):
     _repo_config_cache.clear()
 
     repo = tmp_path / "myrepo"
-    _write_repo_config(
-        repo, [{"rule": "block-force-push-main", "allowedBranches": ["main"]}]
-    )
+    _write_repo_config(repo, [{"rule": "block-force-push-main", "allowedBranches": ["main"]}])
 
     payload = _payload("Bash", {"command": "git push --force origin main"})
     result = evaluate(payload, [_force_push_main_deny_rule()], repo_root=str(repo))
@@ -239,9 +233,7 @@ def test_override_does_not_affect_other_denied_branch(tmp_path):
     _repo_config_cache.clear()
 
     repo = tmp_path / "myrepo"
-    _write_repo_config(
-        repo, [{"rule": "block-push-main", "allowedBranches": ["main"]}]
-    )
+    _write_repo_config(repo, [{"rule": "block-push-main", "allowedBranches": ["main"]}])
 
     payload = _payload("Bash", {"command": "git push origin master"})
     result = evaluate(payload, [_push_main_deny_rule()], repo_root=str(repo))
@@ -285,9 +277,7 @@ def test_allowed_branches_with_no_explicit_branch_still_denies(tmp_path):
     _repo_config_cache.clear()
 
     repo = tmp_path / "myrepo"
-    _write_repo_config(
-        repo, [{"rule": "block-push-main", "allowedBranches": ["main"]}]
-    )
+    _write_repo_config(repo, [{"rule": "block-push-main", "allowedBranches": ["main"]}])
 
     # A push without a branch arg — the deny rule won't match this anyway,
     # but we want to confirm the override doesn't spuriously proceed.
@@ -309,18 +299,11 @@ def test_allowed_paths_and_branches_coexist(tmp_path):
         ],
     )
 
-    read_payload = _payload(
-        "Read", {"file_path": str(repo / ".eval-runs" / "x" / ".env")}
-    )
-    assert (
-        evaluate(read_payload, [_env_deny_rule()], repo_root=str(repo))["decision"]
-        == "proceed"
-    )
+    read_payload = _payload("Read", {"file_path": str(repo / ".eval-runs" / "x" / ".env")})
+    assert evaluate(read_payload, [_env_deny_rule()], repo_root=str(repo))["decision"] == "proceed"
 
     push_payload = _payload("Bash", {"command": "git push origin main"})
     assert (
-        evaluate(push_payload, [_push_main_deny_rule()], repo_root=str(repo))[
-            "decision"
-        ]
+        evaluate(push_payload, [_push_main_deny_rule()], repo_root=str(repo))["decision"]
         == "proceed"
     )

--- a/skills/plan-work/SKILL.md
+++ b/skills/plan-work/SKILL.md
@@ -11,6 +11,7 @@ You are a senior engineer helping to set up a well-scoped implementation plan be
 **Arguments:** $ARGUMENTS
 
 **Pre-loaded context:**
+
 - Current branch: !`~/.claude/skills/shared/scripts/context.sh current-branch`
 - Work folder: !`~/.claude/skills/shared/scripts/context.sh work-folder`
 - Ticket ID: !`~/.claude/skills/shared/scripts/context.sh ticket-id`
@@ -34,6 +35,7 @@ Determine what you're working on. Classify the argument by matching these patter
 ### If a Linear issue ID was provided:
 
 Fetch the issue using the Linear MCP:
+
 ```
 mcp__claude_ai_Linear__get_issue { "issueId": "<ID>" }
 ```
@@ -41,8 +43,15 @@ mcp__claude_ai_Linear__get_issue { "issueId": "<ID>" }
 Summarize the issue title and description in 2–3 sentences and proceed — no confirmation needed unless the issue is ambiguous or has no description.
 
 **Derive the slug:**
-- Pattern: `<lowercase-team>-<number>-<title-fragment>` — e.g. `eng-42-add-dark-mode-settings`
-- **72-char max** on the slug. If a naive kebab-case of the title would exceed it, reformulate a concise but meaningful summary of the title rather than blindly truncating. Example: `eng-42-add-support-for-dark-mode-in-user-settings-and-profile-pages` → `eng-42-dark-mode-settings-profile`. The ticket prefix (`eng-42-`) is never shortened.
+
+- Pattern: `<lowercase-team>-<number>-<fragment>` — e.g. `eng-42-dark-mode-settings`
+- **Always produce a concise fragment.** Pick 2–4 keywords that capture the essence of the ticket — not the literal title. Drop articles, prepositions, filler verbs ("add", "fix", "improve" unless they carry meaning), and detail meant for the ticket body. The fragment should read like a tag, not a sentence.
+- **70-char hard cap on the full slug** (including `<team>-<num>-` prefix). The ticket prefix is never shortened — compress the fragment, not the ticket ID.
+- Examples:
+  - "Add support for dark mode in user settings and profile pages" → `eng-42-dark-mode-settings`
+  - "Fix loan export when borrower has multiple co-applicants" → `lc-22054-loan-export-coapplicants`
+  - "Make info icons smaller and gray on USDA and Residual Income screens" → `lc-21871-info-icon-styling`
+  - "Improve UX of the deployment dashboard" → `lc-17331-deployments-ux`
 - Use the same slug for: branch suffix, worktree directory name, and the work folder (`<work-folder>` from pre-loaded context).
 
 **Track:** store the Linear issue ID in the plan frontmatter as `linear-issue`.
@@ -50,6 +59,7 @@ Summarize the issue title and description in 2–3 sentences and proceed — no 
 ### If a Notion URL was provided:
 
 The Notion page is the **spec or existing plan** — it is the source of intent for this work item. Fetch it:
+
 ```
 mcp__claude_ai_Notion__notion-fetch { "url": "<URL>" }
 ```
@@ -59,13 +69,14 @@ Summarize what the Notion page describes (2–3 sentences). Then ask: "Do you al
 - If they provide a Linear ID → also fetch that issue with `mcp__claude_ai_Linear__get_issue` and use both as context
 - If not → proceed with the Notion page as the sole source
 
-**Derive the slug:** from the Notion page title. If a Linear ID was provided, prefix with it (`eng-42-<title-fragment>`); otherwise use the page title alone. Apply the same 72-char cap and AI reformulation rule — concise essence over blind truncation. Use this slug consistently for branch, worktree, and work folder.
+**Derive the slug:** from the Notion page title. If a Linear ID was provided, prefix with it (`eng-42-<fragment>`); otherwise use the page title alone. Apply the same slug rule as the Linear section above — concise 2–4 keyword fragment, 70-char hard cap on the full slug. Use consistently for branch, worktree, and work folder.
 
 **Track:** store the Notion URL in the plan frontmatter as `notion-source`.
 
 ### If a GitHub issue was provided:
 
 Fetch the issue details:
+
 ```bash
 gh issue view <number> --json title,body,labels,assignees,milestone
 ```
@@ -73,8 +84,9 @@ gh issue view <number> --json title,body,labels,assignees,milestone
 Summarize the issue in 2–3 sentences and proceed.
 
 **Derive the slug:**
-- Pattern: `<number>-<title-fragment>` — e.g. `42-add-dark-mode-settings`
-- Same 72-char cap and AI reformulation rule applies. Use consistently for branch, worktree, and work folder.
+
+- Pattern: `<number>-<fragment>` — e.g. `42-dark-mode-settings`
+- Apply the same slug rule as the Linear section above — concise 2–4 keyword fragment, 70-char hard cap on the full slug. Use consistently for branch, worktree, and work folder.
 
 **Track:** store the GitHub issue number in the plan frontmatter as `github-issue`.
 
@@ -87,12 +99,13 @@ Wait for their response.
 - **They provide a Linear ID** → go to the Linear issue flow above
 - **They provide a Notion URL** → go to the Notion flow above
 - **They provide a GitHub issue** → go to the GitHub issue flow above
-- **They provide a description** → restate it in 2–3 sentences to confirm understanding, then generate a slug from the description (e.g. `add-dark-mode-settings`)
+- **They provide a description** → restate it in 2–3 sentences to confirm understanding, then generate a slug from the description (apply the same concise 2–4 keyword fragment rule, e.g. `dark-mode-settings`)
 - **No response / unclear** → ask once more, then stop: "I need a Linear issue ID, Notion URL, GitHub issue, or a description to proceed."
 
 ### Scope the work
 
 After fetching the source material (issue or description), assess whether it describes more work than a single session should tackle. Signs of a large-scope source:
+
 - Multiple distinct deliverables or phases described
 - Broad system-level changes spanning many components
 - The description reads like a project plan, not a single task
@@ -145,6 +158,7 @@ A worktree lets you work on this branch in an isolated directory — useful for 
 2. **No CLAUDE.md guidance:** use the `EnterWorktree` tool to create and enter the worktree, then run `make init` if a Makefile with an `init` target exists. If neither is found, tell the user: "Worktree created, but I couldn't find any initialization config for this repo. You may need to install dependencies manually, or tell me what to run and I'll do it."
 
 **Branch only (no worktree):**
+
 - Already on a non-main branch matching the slug → proceed, no branch creation needed
 - Already on a non-main branch not matching the slug → flag it: "You're on `<current-branch>` — want me to branch from here or from main?"
 - On main/master → `git checkout -b <user-prefix>/<slug>` (check the branch doesn't already exist)
@@ -158,20 +172,20 @@ Before investing in discovery and plan review, gauge the scope of this work.
 
 ### Signals to evaluate
 
-| Signal | Small | Medium | Large |
-|--------|-------|--------|-------|
-| **File footprint** | 1–2 files | 3–5 files | 6+ files |
-| **Path clarity** | Obvious from description | Some unknowns | Many unknowns |
-| **Cross-cutting** | No | Minor | Yes — multiple systems/layers |
-| **Novelty** | Fix or addition to existing pattern | Extends existing patterns | New capability or architecture |
+| Signal             | Small                               | Medium                    | Large                          |
+| ------------------ | ----------------------------------- | ------------------------- | ------------------------------ |
+| **File footprint** | 1–2 files                           | 3–5 files                 | 6+ files                       |
+| **Path clarity**   | Obvious from description            | Some unknowns             | Many unknowns                  |
+| **Cross-cutting**  | No                                  | Minor                     | Yes — multiple systems/layers  |
+| **Novelty**        | Fix or addition to existing pattern | Extends existing patterns | New capability or architecture |
 
 ### Classification
 
-| Scope      | Discovery | Plan Review (`/plan-review`) | Description                                                                   |
-| ---------- | --------- | ---------------------------- | ----------------------------------------------------------------------------- |
-| **Small**  | Skip      | Skip                         | Single concern, clear path, 1–2 files. Write the plan directly in session.    |
+| Scope      | Discovery | Plan Review (`/plan-review`) | Description                                                                       |
+| ---------- | --------- | ---------------------------- | --------------------------------------------------------------------------------- |
+| **Small**  | Skip      | Skip                         | Single concern, clear path, 1–2 files. Write the plan directly in session.        |
 | **Medium** | Run       | Optional — mention it        | A few files, some unknowns to resolve. Discovery adds value; full review may not. |
-| **Large**  | Run       | Recommend                    | Cross-cutting, architectural, or many unknowns. Full process.                 |
+| **Large**  | Run       | Recommend                    | Cross-cutting, architectural, or many unknowns. Full process.                     |
 
 ### Present your recommendation
 
@@ -199,12 +213,14 @@ Now that you know what you're building, explore the codebase.
 Read `CLAUDE.md` and `.claude/rules/` (if present) to understand project conventions, tech stack, and verification commands. Note the verification commands — you'll need them for the plan.
 
 ### Spawn a discovery agent. Pass it the following explicitly (don't assume it can find things):
+
 - The work item description
 - The full contents of `CLAUDE.md` (if it exists)
 - The repo root path
 - `repo_owner` and `repo_name` parsed from the pre-loaded "Repo remote" context (format: `owner/repo`)
 
 Agent prompt:
+
 > "You are exploring a codebase to inform an implementation plan.
 >
 > Work item: [summarize the goal in 1–2 sentences]
@@ -213,6 +229,7 @@ Agent prompt:
 > [paste CLAUDE.md contents]
 >
 > Explore the codebase to find:
+>
 > 1. The most relevant existing files (entry points, related components, data models, API handlers, tests) — for each file, one sentence on why it's relevant
 > 2. Patterns to follow — how similar features are structured in this repo
 > 3. Potential impact zones — what else might break or need updating
@@ -235,6 +252,7 @@ Synthesize the issue context and discovery findings into a phased implementation
 ### Phase structure rules
 
 Each phase must be:
+
 - **Committable** — leaves the codebase in a working, verifiable state
 - **Testable** — has a concrete verify step (a test command, a manual check, a specific assertion)
 - **Focused** — one logical concern (data model, API layer, UI, tests, migration, etc.)
@@ -248,6 +266,7 @@ Save to `<work-folder>/plan.md` (create the directory with `mkdir -p` if it does
 **Read the full template** at `~/.claude/skills/plan-work/references/plan-template.md` before writing the plan — it has the exact structure that `/do-work`, `/plan-review`, and `/super-work` depend on.
 
 Key structural rules:
+
 - Phases are logical milestones (data model, API, UI, etc.). Tasks within a phase are individual commits.
 - **Multi-repo work:** add `**Repo:** <owner/repo>` as the first line of any phase that belongs to a repo other than the current one. Omit this line entirely for single-repo work. `/do-work` uses this to filter phases by the repo it's running in; `/super-work` uses it to enumerate which workspaces to open.
 - If the work spans multiple repos and it's not clear from the source material, ask: "Does this touch more than one repo? If so, which ones, and how should the phases split across them?" before drafting.
@@ -255,6 +274,7 @@ Key structural rules:
 ### Multi-repo phase detection
 
 During synthesis, check whether the work item or discovery findings touch code in more than one repo. Signals:
+
 - Issue mentions multiple services/apps with separate repos
 - Discovery agent found relevant files in a repo different from the current one
 - Notion spec describes work across distinct systems
@@ -280,6 +300,7 @@ After drafting the plan but before presenting it to the user, determine whether 
 ## Phase 3: Present, Revise & Save
 
 Present the plan. Walk through:
+
 - What each phase delivers and why you structured it that way
 - Any open questions that should be resolved before starting
 - The proposed branch name
@@ -301,7 +322,7 @@ Ask: **"Any changes to the plan before we start?"**
 - **Linear is the default work item source.** When the user provides a Linear issue ID, fetch it via MCP and treat it as the authoritative work item. GitHub issues are supported but secondary. When neither is provided, ask for a Linear ID first.
 - **Notion pages are specs, not plans.** A Notion URL is source material — the intent behind the work. Synthesize it into the plan; don't copy it verbatim. If both Notion and Linear are provided, use both: Notion for the "what and why", Linear for scope, priority, and assignment context.
 - **Discovery before plan (medium/large).** Don't skip the discovery agent for medium and large scope — a plan without codebase context is guesswork. Small scope trades thoroughness for speed; the user accepted that tradeoff when they chose small.
-- **Issues are context, not commands.** Treat the issue as the best available description of intent at the time it was written. Your job is to figure out what good work looks like *now*, given the current state of the codebase. The issue informs the goal; the code determines the approach.
+- **Issues are context, not commands.** Treat the issue as the best available description of intent at the time it was written. Your job is to figure out what good work looks like _now_, given the current state of the codebase. The issue informs the goal; the code determines the approach.
 - **Challenge the issue before following it.** Compare what the issue says against what you actually find. If there's a mismatch — stale assumptions, already-completed work, a changed interface, a better path — surface it and collaborate with the user rather than blindly following the issue.
 - **Propose alternatives when you see them.** If discovery reveals a clearly better approach, raise it. Present tradeoffs, not a verdict. The user decides.
 - **Be specific in tasks.** "Update `src/models/user.ts` to add `darkMode: boolean`" is useful. "Add dark mode support" is not.

--- a/skills/shared/references/linear-mark-in-progress.md
+++ b/skills/shared/references/linear-mark-in-progress.md
@@ -1,0 +1,88 @@
+# Mark a Linear Ticket "In Progress"
+
+Procedure for transitioning a Linear ticket to its team's "in progress" status when work begins. Used by `/start-work`, `/super-work`, and any other skill that initiates work on a ticket.
+
+**Skip this entirely if no Linear ticket is involved** (e.g. slug-only / free-text path).
+
+---
+
+## Step 1 — Check current state
+
+Inspect the `state` from the `get_issue` response (`state.type` and `state.name`):
+
+- `state.type === "started"` → already in progress (or in a downstream started state like "In Review"). **Skip the transition.** Don't regress a deliberate forward move.
+- `state.type === "completed"` or `"canceled"` → ask: "Ticket `<TICKET>` is `<state.name>`. Continue anyway?" If yes, **skip the transition** and proceed. If no, stop the whole skill.
+- Otherwise (`backlog`, `unstarted`, `triage`) → continue to step 2.
+
+---
+
+## Step 2 — Resolve the team's "in-progress" state ID
+
+Read `linear_team_statuses.<TEAM>.in-progress` from `~/.claude/agent-skills.json`, where `<TEAM>` is the **uppercase** team prefix from the ticket ID (e.g. `LC` for `LC-12345`).
+
+The schema is intentionally semantic and extensible — future transitions (`in-review`, `done`, …) slot in alongside `in-progress`:
+
+```json
+{
+  "linear_team_statuses": {
+    "LC": {
+      "in-progress": "<state-uuid>"
+    }
+  }
+}
+```
+
+### If configured
+
+Use the saved state ID. If the transition later fails with "state not found" (e.g. status was deleted in Linear), invalidate the cached value and re-run step 2 from scratch.
+
+### If not configured
+
+Discover the state via the Linear API. The team's UUID comes from the `get_issue` response (`team.id`):
+
+```
+mcp__claude_ai_Linear__list_issue_statuses { "teamId": "<team-uuid>" }
+```
+
+Filter to statuses where `type === "started"`:
+
+- **Exactly one** → use it, save silently. Report: "Saved `<TEAM>.in-progress` = `<state-name>`."
+- **Multiple** (e.g. "In Progress", "In Review", "In QA") → ask: "For team `<TEAM>`, which status means _actively working_? [list options]". Save the chosen state ID.
+- **Zero** → warn "No `started` status found for team `<TEAM>` — skipping transition." Continue the calling skill without transitioning.
+
+Save to config:
+
+```bash
+python3 -c "
+import json, os
+path = os.path.expanduser('~/.claude/agent-skills.json')
+d = json.load(open(path))
+d.setdefault('linear_team_statuses', {}).setdefault('<TEAM>', {})['in-progress'] = '<state-id>'
+json.dump(d, open(path, 'w'), indent=2)
+"
+```
+
+---
+
+## Step 3 — Transition the issue
+
+```
+mcp__claude_ai_Linear__save_issue { "issueId": "<TICKET>", "stateId": "<state-id>" }
+```
+
+Report: "Marked `<TICKET>` → `<state-name>` in Linear."
+
+If the API call fails (auth error, network, permission), **report the error and continue** — don't block the calling skill on a Linear hiccup. The user can move the ticket manually.
+
+---
+
+## Extension notes
+
+When a future skill needs a different transition (e.g. `/finish-work` → mark `in-review`), reuse this same lookup pattern with a different semantic key:
+
+```
+linear_team_statuses.<TEAM>.in-review
+linear_team_statuses.<TEAM>.done
+```
+
+The discovery logic stays the same — filter `list_issue_statuses` results by the appropriate `type` (`started` for in-progress / in-review work, `completed` for done) and ask the user to pick if multiple match.

--- a/skills/start-work/SKILL.md
+++ b/skills/start-work/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: start-work
+description: Create a git worktree for a ticket, run repo setup (conductor / superset / custom), and optionally launch your editor. Local counterpart to /super-work. Give it a Linear ID (e.g. LC-12345), pass a slug, or run with no args to be prompted.
+argument-hint: "[LINEAR-ID | slug]"
+---
+
+# Start Work: Worktree + Setup for a Ticket
+
+You are setting up a fresh git worktree for a work item so the user can start coding in isolation. Resolve the ticket, pick the source repo, create the worktree, run repo-specific setup, and optionally launch the editor.
+
+This is the local-filesystem counterpart to `/super-work` (which creates Superset workspaces). Use this when the user wants a plain `git worktree` they can open in their own editor (VS Code, Cursor, Zed, …).
+
+**Arguments:** $ARGUMENTS
+
+**Pre-loaded context:**
+
+- Ticket ID (from branch): !`~/.claude/skills/shared/scripts/context.sh ticket-id`
+- User branch prefix: !`~/.claude/skills/shared/scripts/context.sh user-slug`
+- Repo remote: !`~/.claude/skills/shared/scripts/context.sh repo-remote`
+- Current branch: !`~/.claude/skills/shared/scripts/context.sh current-branch`
+- Config: !`cat ~/.claude/agent-skills.json 2>/dev/null || echo "needs-setup"`
+
+**Setup check:** If `Config` shows `needs-setup`, stop: "Run `/setup-agent-skills` first to configure your work folder and branch prefix, then come back."
+
+---
+
+## Phase 0: Resolve the Work Item
+
+Determine which ticket to start, in priority order:
+
+1. **Argument** — if `$ARGUMENTS` matches `[A-Z]+-\d+` (Linear ID), use it directly.
+2. **Session context** — if `/plan-work` produced a ticket + slug in this conversation, use them.
+3. **Slug argument** — if `$ARGUMENTS` doesn't match the Linear pattern but looks like a slug (contains a hyphen, no spaces), use it as the slug and derive the ticket if it starts with one.
+4. **Ask** — "What ticket are you starting? Give me a Linear ID (e.g. `LC-12345`)."
+
+Once you have a Linear ID, fetch the issue:
+
+```
+mcp__claude_ai_Linear__get_issue { "issueId": "<TICKET>" }
+```
+
+**Derive the slug** (same rule as `/plan-work`):
+
+- Pattern: `<lowercase-team>-<number>-<fragment>` — e.g. `lc-12345-loan-export`
+- **Always produce a concise fragment.** Pick 2–4 keywords that capture the essence — not the literal title. Drop articles, prepositions, filler verbs ("add", "fix", "improve" unless they carry meaning), and detail meant for the ticket body. The fragment should read like a tag, not a sentence.
+- **70-char hard cap on the full slug** (including `<team>-<num>-` prefix). The ticket prefix is never shortened — compress the fragment, not the ticket ID.
+- Examples:
+  - "Fix loan export when borrower has multiple co-applicants" → `lc-22054-loan-export-coapplicants`
+  - "Make info icons smaller and gray on USDA and Residual Income screens" → `lc-21871-info-icon-styling`
+  - "Improve UX of the deployment dashboard" → `lc-17331-deployments-ux`
+
+The team prefix is everything before the first `-` of the ticket ID, lowercased (e.g. `LC-12345` → team `lc`). Use the **uppercase** team prefix (`LC`) as the config key for Linear-related lookups; use the lowercase form for filesystem things.
+
+---
+
+## Phase 1: Mark the Linear Ticket "In Progress"
+
+Skip this phase entirely if no Linear ticket is involved (slug-only / free-text path). Otherwise, transition the ticket so teammates can see you've picked it up.
+
+Read `~/.claude/skills/shared/references/linear-mark-in-progress.md` and follow it precisely. It covers state-check, per-team status resolution + caching to `linear_team_statuses.<TEAM>.in-progress` in `~/.claude/agent-skills.json`, and the API transition. On any Linear API failure, report and continue — don't block worktree setup.
+
+---
+
+## Phase 2: Resolve Source Repo (by team)
+
+Read `team_repos` from `~/.claude/agent-skills.json` — a map of lowercase team prefix → absolute path to the source repo.
+
+```json
+{ "team_repos": { "lc": "/Volumes/Code/Repos/loancrate/loancrate" } }
+```
+
+- **Match found** → verify the path exists and is a git repo: `git -C <path> rev-parse --is-inside-work-tree`. If verification fails, warn and ask the user to re-enter the path (then re-save).
+- **No match** → ask:
+
+  > "I don't have a repo configured for team `<TEAM>`. What's the absolute path to its source repo?"
+
+  Verify the answer is a git repo, then save:
+
+  ```bash
+  python3 -c "
+  import json, os
+  path = os.path.expanduser('~/.claude/agent-skills.json')
+  d = json.load(open(path))
+  d.setdefault('team_repos', {})['<team>'] = '<absolute-path>'
+  json.dump(d, open(path, 'w'), indent=2)
+  "
+  ```
+
+The resolved source repo is `<source-repo>`. From here on, run all `git` commands with `-C <source-repo>` unless otherwise noted.
+
+---
+
+## Phase 3: Compute Branch and Worktree Path
+
+- **Branch name**: `<user-prefix>/<slug>` (lowercase throughout) — e.g. `ambrose/lc-12345-fix-loan-export`. Matches the convention used by `/plan-work` and `/super-work`.
+- **Worktree path**: sibling of `<source-repo>`, named with the slug.
+  - Source: `/Volumes/Code/Repos/loancrate/loancrate`
+  - Worktree: `/Volumes/Code/Repos/loancrate/lc-12345-fix-loan-export`
+
+Check existing state:
+
+```bash
+git -C <source-repo> worktree list --porcelain
+git -C <source-repo> branch --list <branch>
+```
+
+Branching on what you find:
+
+- **Worktree already exists at that path or for that branch** → ask: "Worktree already exists at `<existing-path>` for `<branch>`. Open editor there instead of recreating?" If yes, skip to Phase 7 (Launch Editor) with the existing path. If no, stop and let the user decide.
+- **Branch exists locally but no worktree** → offer to attach: `git worktree add <path> <branch>`. Skip the `-b` and base-branch steps below.
+- **Path exists on disk but isn't a git worktree** → stop and warn. Don't overwrite anything.
+- **Clean state** → continue.
+
+---
+
+## Phase 4: Confirm Base Branch
+
+Determine the default base:
+
+```bash
+git -C <source-repo> symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|^refs/remotes/origin/||'
+```
+
+Fall back to `main` if the symbolic ref isn't set.
+
+Ask:
+
+> "Branch `<branch>` will be created from `<base>`. OK, or branch from somewhere else?"
+
+Fetch latest before branching:
+
+```bash
+git -C <source-repo> fetch origin <base>
+```
+
+---
+
+## Phase 5: Create the Worktree
+
+```bash
+git -C <source-repo> worktree add -b <branch> <worktree-path> origin/<base>
+```
+
+If this fails (locked worktree, branch name conflict, dirty index, etc.), report the error verbatim and stop — don't attempt clever recovery without user input.
+
+---
+
+## Phase 6: Run Setup
+
+Read `repo_setup` from `~/.claude/agent-skills.json` — a map of `<source-repo-absolute-path>` → setup command string. Placeholders supported inside the command:
+
+- `{WORKTREE}` → absolute worktree path
+- `{SOURCE}` → absolute source-repo path
+
+**If configured** → expand placeholders and run from the worktree directory.
+
+**If not configured**, auto-detect in this order (run each check against the worktree, not the source repo):
+
+1. **Conductor** — `<worktree>/conductor_setup.sh` exists
+   → command: `CONDUCTOR_ROOT_PATH={SOURCE} bash conductor_setup.sh`
+2. **Superset** — `<worktree>/.superset/config.json` exists and has a `setup` array
+   → join entries with `&&`; replace `$SUPERSET_ROOT_PATH` with `{SOURCE}`
+3. **Generic** — `<worktree>/scripts/setup.sh` exists
+   → command: `bash scripts/setup.sh`
+4. **None match** → ask: "I didn't detect a setup script for this repo. What command should I run inside the worktree? (Or type `skip`.)" Use `{WORKTREE}` and `{SOURCE}` placeholders if relevant.
+
+After detecting (or being given) a command, ask:
+
+> "Detected setup command: `<command>`. Save this as the default for `<source-repo>`?"
+
+If yes, save under `repo_setup.<source-repo-absolute-path>` in agent-skills.json.
+
+**Run it.** Stream output to the user (don't background — they want to see the install). If it fails, report which step failed and stop. The worktree still exists; the user can investigate and re-run setup manually with the command you printed.
+
+---
+
+## Phase 7: Launch Editor
+
+Read `editor_command` from `~/.claude/agent-skills.json`.
+
+**If not set:**
+
+- Ask: "What editor should I launch new worktrees in? (e.g. `code` for VS Code, `cursor`, `zed`, or `none` to skip.)"
+- If they pick something other than `none`, verify the command resolves: `command -v <editor>`. If it doesn't, tell them and re-ask.
+- Save to `editor_command` in agent-skills.json (use the string `none` to disable).
+
+**If `none`** → print `cd <worktree-path>` and skip launch.
+
+**Otherwise** → launch in background:
+
+```bash
+<editor> <worktree-path>
+```
+
+---
+
+## Phase 8: Confirm
+
+Report concisely:
+
+- **Worktree:** `<worktree-path>`
+- **Branch:** `<branch>` (from `origin/<base>`)
+- **Setup:** succeeded / failed / skipped
+- **Editor:** launched `<editor>` / skipped (with `cd` command)
+- **Cleanup hint:** "When done, run `bash ~/.claude/skills/start-work/scripts/cleanup-worktree.sh <worktree-path>` to remove the worktree and branch. With no arg, you'll get an fzf picker of linked worktrees in the current repo."
+
+Stop. Don't auto-start the dev server — that's the user's call (or handled by Conductor/Superset which have their own run scripts).
+
+---
+
+## Cleanup
+
+Cleanup is deterministic — no AI needed. The companion script handles it:
+
+```bash
+bash ~/.claude/skills/start-work/scripts/cleanup-worktree.sh [<worktree-path-or-branch>] [--force]
+```
+
+With no target, it opens an fzf picker listing linked worktrees in the current repo (excluding the main worktree). It verifies the worktree is clean and the branch is merged (or has a merged PR) before removing. `--force` skips those checks.
+
+---
+
+## Guidelines
+
+- **One worktree per ticket per repo.** If one already exists, offer to switch the editor to it rather than recreating.
+- **Lowercase slugs.** Match `/plan-work` and `/super-work`. The branch name is `<prefix>/<slug>`, all lowercase.
+- **Sibling-of-source path layout.** Predictable, visible, easy to clean up.
+- **Don't touch the source repo's working tree.** Only `git worktree add` from it. Fetch is fine.
+- **Don't auto-start dev servers.** Setup builds; the user (or their tooling) starts `pnpm dev` / equivalent.
+- **Surface failures, don't paper over them.** If setup fails, leave the worktree in place and tell the user what command to re-run.

--- a/skills/start-work/scripts/cleanup-worktree.sh
+++ b/skills/start-work/scripts/cleanup-worktree.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# cleanup-worktree.sh — remove a git worktree and its branch.
+#
+# Usage:
+#   cleanup-worktree.sh [<worktree-path|branch-name>] [--force] [--keep-branch]
+#
+# With no target, opens an fzf picker listing linked worktrees in the current
+# repo (excludes the main worktree). Requires fzf.
+#
+# Verifies the worktree has no uncommitted changes and the branch is merged
+# (into origin/<default> OR via a merged PR) before removing.
+#
+#   --force         Skip cleanliness + merge checks. Forces worktree remove
+#                   and branch delete (-D).
+#   --keep-branch   Remove the worktree only; leave the branch behind.
+
+set -euo pipefail
+
+force=false
+keep_branch=false
+target=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --force) force=true ;;
+    --keep-branch) keep_branch=true ;;
+    -h|--help)
+      sed -n '2,/^set -euo/p' "$0" | sed '$d' | sed 's/^# \?//'
+      exit 0 ;;
+    -*)
+      echo "Unknown flag: $arg" >&2
+      exit 1 ;;
+    *)
+      if [[ -n "$target" ]]; then
+        echo "Error: multiple targets given ('$target' and '$arg')" >&2
+        exit 1
+      fi
+      target="$arg" ;;
+  esac
+done
+
+# ----------------------------------------------------------------------------
+# No target → fzf picker over linked worktrees in the current repo
+# ----------------------------------------------------------------------------
+
+if [[ -z "$target" ]]; then
+  if ! command -v fzf &>/dev/null; then
+    echo "Usage: $(basename "$0") [<worktree-path|branch-name>] [--force] [--keep-branch]" >&2
+    echo "(Install fzf to pick interactively: brew install fzf)" >&2
+    exit 1
+  fi
+
+  if ! cwd_top="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    echo "Error: no target given, and you're not inside a git repo." >&2
+    echo "Run this from inside the source repo (or any worktree), or pass a path/branch." >&2
+    exit 1
+  fi
+
+  git_common="$(git -C "$cwd_top" rev-parse --git-common-dir)"
+  [[ "$git_common" != /* ]] && git_common="$cwd_top/$git_common"
+  main_repo="$(cd "$(dirname "$git_common")" && pwd)"
+
+  worktree_list="$(git -C "$main_repo" worktree list | awk -v main="$main_repo" '$1 != main')"
+  if [[ -z "$worktree_list" ]]; then
+    echo "No linked worktrees to clean up (only main repo at $main_repo)." >&2
+    exit 1
+  fi
+
+  target="$(echo "$worktree_list" | fzf --height=40% --reverse --prompt="Cleanup worktree: " | awk '{print $1}')"
+  if [[ -z "$target" ]]; then
+    echo "No worktree selected." >&2
+    exit 1
+  fi
+fi
+
+# ----------------------------------------------------------------------------
+# Resolve target → worktree_path, branch, source_repo
+# ----------------------------------------------------------------------------
+
+worktree_path=""
+branch=""
+source_repo=""
+
+if [[ -d "$target" ]] && git -C "$target" rev-parse --is-inside-work-tree &>/dev/null; then
+  worktree_path="$(cd "$target" && pwd)"
+  git_common="$(git -C "$worktree_path" rev-parse --git-common-dir)"
+  source_repo="$(cd "$(dirname "$git_common")" && pwd)"
+  branch="$(git -C "$worktree_path" branch --show-current || true)"
+else
+  # Treat target as a branch name; find the worktree from the cwd's repo.
+  branch="$target"
+  if ! source_repo="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    echo "Error: '$target' is not a worktree path, and you're not inside a git repo." >&2
+    echo "Run this from inside the source repo, or pass an absolute worktree path." >&2
+    exit 1
+  fi
+  source_repo="$(cd "$source_repo" && pwd)"
+
+  wt_path=""
+  while IFS= read -r line; do
+    case "$line" in
+      "worktree "*) wt_path="${line#worktree }" ;;
+      "branch refs/heads/$branch")
+        worktree_path="$wt_path" ;;
+    esac
+  done < <(git -C "$source_repo" worktree list --porcelain)
+
+  if [[ -z "$worktree_path" ]]; then
+    echo "Error: no worktree found for branch '$branch' in $source_repo." >&2
+    exit 1
+  fi
+fi
+
+if [[ "$worktree_path" == "$source_repo" ]]; then
+  echo "Error: refusing to remove the main worktree at $source_repo." >&2
+  exit 1
+fi
+
+if [[ -z "$branch" ]]; then
+  echo "Error: worktree at $worktree_path is detached (no branch)." >&2
+  echo "Use 'git worktree remove $worktree_path' manually." >&2
+  exit 1
+fi
+
+echo "Worktree: $worktree_path"
+echo "Branch:   $branch"
+echo "Source:   $source_repo"
+echo
+
+# ----------------------------------------------------------------------------
+# Safety checks (unless --force)
+# ----------------------------------------------------------------------------
+
+if [[ "$force" != "true" ]]; then
+  # 1. No uncommitted changes
+  if ! git -C "$worktree_path" diff --quiet || ! git -C "$worktree_path" diff --cached --quiet; then
+    echo "Error: worktree has uncommitted changes." >&2
+    echo "Commit/stash them, or pass --force." >&2
+    exit 1
+  fi
+
+  # 2. Untracked files — prompt
+  if [[ -n "$(git -C "$worktree_path" ls-files --others --exclude-standard)" ]]; then
+    echo "Warning: worktree has untracked files."
+    read -r -p "Continue anyway? [y/N] " ans
+    [[ "$ans" =~ ^[Yy]$ ]] || { echo "Aborted."; exit 1; }
+  fi
+
+  # 3. Branch is merged — into origin/<default> OR via a merged PR
+  default_base="$(git -C "$source_repo" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null \
+    | sed 's|^origin/||' || echo main)"
+  git -C "$source_repo" fetch origin "$default_base" --quiet 2>/dev/null || true
+
+  merged=false
+  if git -C "$source_repo" merge-base --is-ancestor "refs/heads/$branch" "origin/$default_base" 2>/dev/null; then
+    merged=true
+    echo "Branch is an ancestor of origin/$default_base."
+  elif command -v gh &>/dev/null; then
+    repo_slug="$(git -C "$source_repo" remote get-url origin | sed -E 's|.*github\.com[:/]||; s|\.git$||')"
+    pr_state="$(gh -R "$repo_slug" pr list --head "$branch" --state all --json state --jq '.[0].state' 2>/dev/null || true)"
+    if [[ "$pr_state" == "MERGED" ]]; then
+      merged=true
+      echo "PR for $branch is MERGED on GitHub."
+    elif [[ -n "$pr_state" ]]; then
+      echo "PR state: $pr_state (not MERGED)."
+    fi
+  fi
+
+  if [[ "$merged" != "true" ]]; then
+    echo "Error: branch '$branch' is not merged into origin/$default_base and has no merged PR." >&2
+    echo "Pass --force to remove anyway." >&2
+    exit 1
+  fi
+fi
+
+# ----------------------------------------------------------------------------
+# Remove worktree
+# ----------------------------------------------------------------------------
+
+if [[ "$force" == "true" ]]; then
+  git -C "$source_repo" worktree remove --force "$worktree_path"
+else
+  git -C "$source_repo" worktree remove "$worktree_path"
+fi
+echo "✓ Worktree removed: $worktree_path"
+
+# ----------------------------------------------------------------------------
+# Delete branch
+# ----------------------------------------------------------------------------
+
+if [[ "$keep_branch" == "true" ]]; then
+  echo "· Branch kept: $branch"
+elif git -C "$source_repo" show-ref --verify --quiet "refs/heads/$branch"; then
+  # Always -D: our own check above is the merge gate. git's -d uses a stricter
+  # local-only definition that misses squash/rebase merges on GitHub.
+  git -C "$source_repo" branch -D "$branch"
+  echo "✓ Branch deleted: $branch"
+fi
+
+echo
+echo "Done."

--- a/skills/super-work/SKILL.md
+++ b/skills/super-work/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: super-work
-description: Open a Superset workspace for a work item. Discovers context from the current session, branch, or a given Linear ID — creates the workspace on the right repo/branch and switches to it. Run this when you're ready to start coding in Superset.
+description: Open a Superset workspace for a work item. Discovers context from the current session, branch, or a given Linear ID — creates the workspace on the right repo/branch. Run this when you're ready to start coding in Superset.
 argument-hint: "[LINEAR-ID | slug]"
 ---
 
 # Super Work: Launch a Superset Workspace
 
-You are creating and switching to a Superset workspace for a work item. Your job is to figure out what to work on, set up the workspace on the right repo and branch, and hand off to the user inside Superset.
+You are creating a Superset workspace for a work item. Your job is to figure out what to work on, set up the workspace on the right repo and branch, and hand off to the user to open it in the Superset desktop app.
 
 **Arguments:** $ARGUMENTS
 
@@ -16,8 +16,22 @@ You are creating and switching to a Superset workspace for a work item. Your job
 - Work folder (from branch): !`~/.claude/skills/shared/scripts/context.sh work-folder`
 - User branch prefix: !`~/.claude/skills/shared/scripts/context.sh user-slug`
 - Repo remote: !`~/.claude/skills/shared/scripts/context.sh repo-remote`
+- Superset CLI: !`command -v superset >/dev/null 2>&1 && (superset hosts list --quiet >/dev/null 2>&1 && echo "ready" || echo "needs-login") || echo "not-installed"`
 
-**Setup check:** If `Work folder` shows `needs-setup`, stop: "Run `/setup-agent-skills` first to configure your work folder, then come back."
+**Setup checks (in order):**
+
+1. If `Work folder` shows `needs-setup`, stop: "Run `/setup-agent-skills` first to configure your work folder, then come back."
+
+2. If `Superset CLI` shows `not-installed`, stop: "The Superset CLI isn't installed. Install it with:
+
+   ```
+   brew tap superset-sh/tap
+   brew install superset-sh/tap/superset
+   ```
+
+   Then re-run `/super-work`."
+
+3. If `Superset CLI` shows `needs-login`, stop: "Superset CLI is installed but not authenticated. Run `superset auth login` (or set `SUPERSET_API_KEY`), then re-run `/super-work`."
 
 ---
 
@@ -60,29 +74,31 @@ The selected repo is `<target-repo>`.
 
 ---
 
-## Phase 3: Resolve Device and Project IDs
+## Phase 3: Resolve Host and Project IDs
 
-### Device ID
+All Superset calls run through the `superset` CLI. The CLI emits JSON automatically when invoked from a Claude Code session, so no `--json` flag is needed — but adding it never hurts and makes intent explicit.
 
-Read `device_id` from `~/.claude/agent-skills.json`.
+### Host ID
+
+Read `host_id` from `~/.claude/agent-skills.json`. (Older configs may have `device_id` — ignore it and create a fresh `host_id`.)
 
 If not present:
 
-```
-mcp__superset__list_devices {}
+```bash
+superset hosts list --json
 ```
 
-- One device → use it automatically
-- Multiple → ask which to use
+- One host → use it automatically
+- Multiple → ask which to use (match on name)
 
-Save `device_id` to `~/.claude/agent-skills.json`:
+Save `host_id` to `~/.claude/agent-skills.json`:
 
 ```bash
 python3 -c "
 import json, os
 path = os.path.expanduser('~/.claude/agent-skills.json')
 d = json.load(open(path))
-d['device_id'] = '<device-id>'
+d['host_id'] = '<host-id>'
 json.dump(d, open(path, 'w'), indent=2)
 "
 ```
@@ -93,11 +109,11 @@ Read `projects` map from `~/.claude/agent-skills.json` — keyed by repo remote 
 
 If `<target-repo>` is not in the map:
 
-```
-mcp__superset__list_projects { "deviceId": "<device-id>" }
+```bash
+superset projects list --json
 ```
 
-Match by name or path against `<target-repo>`. If ambiguous, ask the user to pick.
+Match by name or path against `<target-repo>` (parse JSON with `jq`). If ambiguous, ask the user to pick.
 
 Save to config:
 
@@ -115,16 +131,19 @@ json.dump(d, open(path, 'w'), indent=2)
 
 ## Phase 4: Check for Existing Workspace
 
+```bash
+superset workspaces list --host "<host-id>" --json
 ```
-mcp__superset__list_workspaces { "deviceId": "<device-id>" }
-```
 
-If a workspace already exists whose name matches the slug (or contains the ticket token):
+Parse the JSON and look for a workspace whose name matches the slug (or contains the ticket token).
 
-> "A workspace `<name>` already exists for this ticket. Switch to it instead of creating a new one?"
+If one exists:
 
-- **Yes** → use `mcp__superset__switch_workspace` and skip to Phase 6 (confirm)
-- **No** → continue
+> "A workspace `<name>` already exists for this ticket. Open it in Superset instead of creating a new one."
+
+Stop here — the user opens the existing workspace from the Superset desktop app.
+
+Otherwise, continue to Phase 5.
 
 ---
 
@@ -141,30 +160,21 @@ The confirmed base is `<base-branch>`.
 
 ---
 
-## Phase 6: Create and Switch Workspace
+## Phase 6: Create Workspace
 
-```
-mcp__superset__create_workspace {
-  "deviceId": "<device-id>",
-  "projectId": "<project-id>",
-  "workspaces": [{
-    "name": "<slug>",
-    "branchName": "<user-prefix>/<slug>",
-    "baseBranch": "<base-branch>"
-  }]
-}
+```bash
+superset workspaces create \
+  --host "<host-id>" \
+  --project "<project-id>" \
+  --name "<slug>" \
+  --branch "<user-prefix>/<slug>" \
+  --base-branch "<base-branch>" \
+  --json
 ```
 
-Capture the returned workspace ID. If creation fails, report the error and stop.
+Capture the returned workspace ID from the JSON output. If creation fails (non-zero exit), report the error verbatim and stop.
 
-```
-mcp__superset__switch_workspace {
-  "deviceId": "<device-id>",
-  "workspaceId": "<workspace-id>"
-}
-```
-
-Confirm: "Workspace `<slug>` is open — switch to it in Superset to start working."
+Confirm: "Workspace `<slug>` created — open it in the Superset desktop app to start working."
 
 If the plan has multiple repos with remaining work:
 
@@ -172,12 +182,13 @@ If the plan has multiple repos with remaining work:
 
 ---
 
-## Fallback: Superset Unavailable
+## Fallback: CLI errors
 
-If any Superset call fails with an auth or connection error:
+If any `superset` call exits non-zero, surface the error message and the suggested fix:
 
-1. Report what happened
-2. Tell the user: "Re-authenticate Superset (`claude mcp auth superset`) and run `/super-work` again."
+- `Not logged in` → "Run `superset auth login` (or set `SUPERSET_API_KEY`) and re-run `/super-work`."
+- Connection / network errors → "Couldn't reach Superset. Check `superset status` and your network, then re-run `/super-work`."
+- Anything else → report the full error and stop. Don't retry or guess.
 
 ---
 
@@ -185,6 +196,6 @@ If any Superset call fails with an auth or connection error:
 
 - **A plan is helpful but not required.** A Linear ticket ID alone is enough — slug is derived from the issue title.
 - **One workspace per repo.** For multi-repo work, open them sequentially — run `/super-work` again for each additional repo.
-- **Device and project IDs are cached.** Look them up once, save them, skip the lookup next time.
+- **Host and project IDs are cached.** Look them up once, save them, skip the lookup next time.
 - **The work folder lives outside the repo** — it's accessible from any worktree. No copying needed.
-- **Don't auto-start agents.** Create the workspace and switch to it. The user drives from there.
+- **Don't auto-start agents.** Create the workspace and hand off. The user opens it in the Superset desktop app and drives from there.

--- a/skills/super-work/SKILL.md
+++ b/skills/super-work/SKILL.md
@@ -11,6 +11,7 @@ You are creating and switching to a Superset workspace for a work item. Your job
 **Arguments:** $ARGUMENTS
 
 **Pre-loaded context:**
+
 - Ticket ID (from branch): !`~/.claude/skills/shared/scripts/context.sh ticket-id`
 - Work folder (from branch): !`~/.claude/skills/shared/scripts/context.sh work-folder`
 - User branch prefix: !`~/.claude/skills/shared/scripts/context.sh user-slug`
@@ -30,13 +31,22 @@ Determine which plan to open a workspace for, in priority order:
 4. **Ask** — "What are you working on? Give me a Linear ID or slug."
 
 Once resolved, derive the slug:
+
 - If a plan exists at `<work-folder>/plan.md`, read the `branch` from its frontmatter for the slug.
-- Otherwise derive the slug from the ticket: fetch the Linear issue title with `mcp__claude_ai_Linear__get_issue` and apply the same slug rules as `/plan-work` (lowercase team + number + title fragment, 72-char max).
+- Otherwise derive the slug from the ticket: fetch the Linear issue title with `mcp__claude_ai_Linear__get_issue` and apply the same slug rule as `/plan-work` — concise 2–4 keyword fragment that reads like a tag (drop articles, prepositions, filler verbs); pattern is `<lowercase-team>-<number>-<fragment>`; 70-char hard cap on the full slug. The ticket prefix is never shortened.
 - If argument is already a slug (no `[A-Z]+-\d+` pattern), use it directly.
 
 ---
 
-## Phase 1: Identify Target Repo
+## Phase 1: Mark the Linear Ticket "In Progress"
+
+Skip this phase entirely if no Linear ticket is involved (slug-only / plan-only path). Otherwise, transition the ticket so teammates can see you've picked it up.
+
+Read `~/.claude/skills/shared/references/linear-mark-in-progress.md` and follow it precisely. It covers state-check, per-team status resolution + caching to `linear_team_statuses.<TEAM>.in-progress` in `~/.claude/agent-skills.json`, and the API transition. On any Linear API failure, report and continue — don't block workspace creation.
+
+---
+
+## Phase 2: Identify Target Repo
 
 If a plan exists, scan its phases for `**Repo:**` annotations:
 
@@ -50,20 +60,23 @@ The selected repo is `<target-repo>`.
 
 ---
 
-## Phase 2: Resolve Device and Project IDs
+## Phase 3: Resolve Device and Project IDs
 
 ### Device ID
 
 Read `device_id` from `~/.claude/agent-skills.json`.
 
 If not present:
+
 ```
 mcp__superset__list_devices {}
 ```
+
 - One device → use it automatically
 - Multiple → ask which to use
 
 Save `device_id` to `~/.claude/agent-skills.json`:
+
 ```bash
 python3 -c "
 import json, os
@@ -79,12 +92,15 @@ json.dump(d, open(path, 'w'), indent=2)
 Read `projects` map from `~/.claude/agent-skills.json` — keyed by repo remote (e.g. `loancrate/web`).
 
 If `<target-repo>` is not in the map:
+
 ```
 mcp__superset__list_projects { "deviceId": "<device-id>" }
 ```
+
 Match by name or path against `<target-repo>`. If ambiguous, ask the user to pick.
 
 Save to config:
+
 ```bash
 python3 -c "
 import json, os
@@ -97,7 +113,7 @@ json.dump(d, open(path, 'w'), indent=2)
 
 ---
 
-## Phase 3: Check for Existing Workspace
+## Phase 4: Check for Existing Workspace
 
 ```
 mcp__superset__list_workspaces { "deviceId": "<device-id>" }
@@ -107,12 +123,12 @@ If a workspace already exists whose name matches the slug (or contains the ticke
 
 > "A workspace `<name>` already exists for this ticket. Switch to it instead of creating a new one?"
 
-- **Yes** → use `mcp__superset__switch_workspace` and skip to Phase 5
+- **Yes** → use `mcp__superset__switch_workspace` and skip to Phase 6 (confirm)
 - **No** → continue
 
 ---
 
-## Phase 4: Confirm Base Branch
+## Phase 5: Confirm Base Branch
 
 Ask the user which branch to base the workspace on:
 
@@ -125,7 +141,7 @@ The confirmed base is `<base-branch>`.
 
 ---
 
-## Phase 5: Create and Switch Workspace
+## Phase 6: Create and Switch Workspace
 
 ```
 mcp__superset__create_workspace {
@@ -151,6 +167,7 @@ mcp__superset__switch_workspace {
 Confirm: "Workspace `<slug>` is open — switch to it in Superset to start working."
 
 If the plan has multiple repos with remaining work:
+
 > "When you're ready for the next repo (`<next-repo>`), run `/super-work` again."
 
 ---

--- a/skills/wtf/SKILL.md
+++ b/skills/wtf/SKILL.md
@@ -8,6 +8,16 @@ argument-hint: "<what went wrong>"
 
 When the user catches you doing something wrong, they type `/wtf <what went wrong>`. This skill persists the correction so an autonomous worker can classify and fix it later. The skill returns in <1s; the GitHub backlog update happens in the background.
 
+## Repo override (check first)
+
+Before doing anything else, check whether the current repo provides its own `/wtf` skill. Walk up from `$PWD` until you find a `.git` directory — that's the repo root. If `<repo-root>/.claude/skills/wtf/SKILL.md` exists:
+
+1. Read that file.
+2. Follow its instructions instead of the rest of this skill, treating the user's argument verbatim as: `$ARGUMENTS`.
+3. Stop — do not fall through to the default behavior below.
+
+This lets repos route WTF captures to team- or project-specific destinations (different backlog repo, different sanitization rules, etc.). When no repo-local skill is present, continue with the default behavior.
+
 **Arguments:** `$ARGUMENTS` — free-form description of what went wrong. The user's raw reaction is good; no need to sanitize.
 
 ## Step 1: Capture locally (synchronous)

--- a/templates/ambroselittle.md
+++ b/templates/ambroselittle.md
@@ -42,3 +42,20 @@ test). Don't wait to be prompted.
 - Closely follow repo-specific standards -- they may override these general ones
 - Your work should be provable/testable -- design for that and write thorough tests, following repo guidelines
 - **When reporting timestamps** -- always include the timezone identifier (e.g. `18:05 UTC`, `2:05 PM EDT`). Never show a bare time.
+
+## Prefer `undefined` over `null`
+
+For values we own -- function returns, our own types, signatures -- use `undefined`
+to represent "unset", not `null`. Reasons:
+
+- `field?: T` is more concise than `field: T | null` plus a literal `null` everywhere.
+- JSON serialization can omit the property entirely instead of carrying a `null`.
+- One concept, one representation.
+
+Exceptions where `null` is unavoidable: GraphQL codegen output (nullable scalars/fields),
+third-party APIs that produce `null`, and DOM APIs (`document.querySelector` returns `T | null`).
+Don't propose refactoring large existing surfaces (especially GraphQL-shaped code) to
+swap `null` for `undefined` -- consume the `null` and don't re-emit it from our own code.
+
+`x == null` (matches both null and undefined) is fine for boundary checks -- it's already
+permitted by the ESLint config in this repo.


### PR DESCRIPTION
## Summary

Adds `/start-work` — the local-filesystem counterpart to `/super-work`. Creates a git worktree for a Linear ticket, runs repo setup, optionally launches the editor, and transitions the ticket to In Progress.

- **New `/start-work` skill** + `cleanup-worktree.sh` companion (fzf picker when no arg; verifies clean worktree + merged branch, with `--force` and `--keep-branch` escape hatches).
- **`shared/references/linear-mark-in-progress.md`** — extensible per-team status map at `linear_team_statuses.<TEAM>.in-progress` in `~/.claude/agent-skills.json`. Auto-discovers via `list_issue_statuses`; asks once when multiple "started" states exist. Shape supports future semantic keys (`in-review`, `done`, …).
- **`/super-work`** adopts the same in-progress phase.
- **Slug rule tightened** across `plan-work` / `super-work` / `start-work`: concise 2–4 keyword tag-style fragment, 70-char hard cap. "Always concise" replaces the old "reformulate only if cap exceeded".
- Drive-by: `templates/ambroselittle.md` adds "prefer `undefined` over `null`".

## Verification

### Skills
- [x] `setup.sh` cleanly links the new skill
- [x] `cleanup-worktree.sh` smoke-tested: `--help`, no-args usage, missing-branch error path
- [x] End-to-end `/start-work LC-XXXX` run (pending live test)