### PR TITLE
Copyables: print exactly what gets pasted (drop the pbcopy mandate)

### DIFF
--- a/skills/create-repo/SKILL.md
+++ b/skills/create-repo/SKILL.md
@@ -314,17 +314,20 @@ The script handles: `git init`, staging, initial commit with stack description, 
 
 Mark all tasks completed.
 
-Report results, then give the user a quick-start command. On macOS, pipe it to `pbcopy` so it's ready to paste:
-
-Copy the start command to clipboard (adapts by template):
-- TS templates: `echo "cd <output-dir> && pnpm start" | pbcopy`
-- Python templates: `echo "cd <output-dir> && just start" | pbcopy`
+Report results, then give the user a quick-start command **printed in its own fenced code block,
+exactly as it should be pasted** (adapts by template — TS: `cd <output-dir> && pnpm start`;
+Python: `cd <output-dir> && just start`). Don't pipe it to `pbcopy` — the printed block is the
+delivery.
 
 Then report:
 
 > "Your `<project-name>` is ready. Everything builds, tests pass, and the first commit is pushed.
 >
-> Quick start copied to clipboard — paste in a terminal to jump in. (Starts Postgres + dev servers in one command.)
+> Quick start (starts Postgres + dev servers in one command):
+>
+> ```
+> cd <output-dir> && pnpm start
+> ```
 >
 > Next steps:
 > - Run `/plan-work` to plan your first feature

--- a/templates/ambroselittle.md
+++ b/templates/ambroselittle.md
@@ -27,11 +27,6 @@ test). Don't wait to be prompted.
   pasted**: complete, runnable, no shell prompts, no commentary inside the block, no placeholders
   unless explicitly flagged as fill-ins.
 - One copyable per block — don't bundle alternatives or explanation into the same block.
-- Do **not** rely on `pbcopy` as the delivery mechanism. The clipboard is a single mutable
-  register — dictation and app switching clobber it, so it failed most of the time in practice.
-  The terminal renderer copies fenced blocks cleanly (copy-on-select, no line mangling), and
-  Maccy keeps clipboard history, so the printed block IS the delivery. `pbcopy` is at most an
-  optional courtesy for very large payloads — never the only path.
 
 ## Pacing
 

--- a/templates/ambroselittle.md
+++ b/templates/ambroselittle.md
@@ -20,14 +20,18 @@ test). Don't wait to be prompted.
   user runs many parallel sessions and may have pasted into the wrong one. A quick "This seems
   unrelated to [current work] -- intended for this session?" saves wasted effort.
 
-## Clipboard for Runnable Commands
+## Copyables: Print Exactly What Gets Pasted
 
-- When giving the user a command to run (especially multi-line or long commands), **pipe it to
-  `pbcopy`** so it's on their clipboard. Then say something like "Copied to your clipboard — paste
-  in a terminal to run."
-- Terminal output mangles copy-paste — newlines, prompts, and formatting all break. `pbcopy` avoids this.
-- This applies to: install commands, verification commands, URLs, file paths the user needs to
-  navigate to — anything the user will need to copy from your output and use elsewhere.
+- When giving the user anything they'll copy and use elsewhere — commands, URLs, file paths,
+  config snippets — print it in its own fenced code block containing **exactly what should be
+  pasted**: complete, runnable, no shell prompts, no commentary inside the block, no placeholders
+  unless explicitly flagged as fill-ins.
+- One copyable per block — don't bundle alternatives or explanation into the same block.
+- Do **not** rely on `pbcopy` as the delivery mechanism. The clipboard is a single mutable
+  register — dictation and app switching clobber it, so it failed most of the time in practice.
+  The terminal renderer copies fenced blocks cleanly (copy-on-select, no line mangling), and
+  Maccy keeps clipboard history, so the printed block IS the delivery. `pbcopy` is at most an
+  optional courtesy for very large payloads — never the only path.
 
 ## Pacing
 


### PR DESCRIPTION
## Summary

Replace the "always pipe copyables to \`pbcopy\`" convention with: **print it in its own fenced code block, exactly as it should be pasted** — complete, runnable, no prompts or commentary inside the block, one copyable per block.

Why: the clipboard is a single mutable register — dictation and app switching clobber it, so pbcopy delivery failed ~90% of the time in practice. The new Claude terminal renderer now copies fenced blocks cleanly (copy-on-select, no line mangling), and Maccy provides clipboard history, so the printed block is the reliable delivery path. \`pbcopy\` is demoted to an optional courtesy for very large payloads.

- \`templates/ambroselittle.md\` — "Clipboard for Runnable Commands" → "Copyables: Print Exactly What Gets Pasted"
- \`skills/create-repo/SKILL.md\` — quick-start command printed in a fenced block instead of piped to pbcopy

## Verification

Guidance/prose only — no scripts, hooks, or scaffolding behavior changed. Deploy after merge with \`bash setup.sh\` to refresh \`~/.claude/CLAUDE.md\`.