### PR TITLE
feat(hooks): block secret-named file reads + case-insensitive path matching

### DIFF
--- a/hooks/PreToolUse/CLAUDE.md
+++ b/hooks/PreToolUse/CLAUDE.md
@@ -34,6 +34,13 @@ Rules in `rules.json` match by either:
 - **`operation`** — a named operation handler (e.g. `read-path`, `git-force-push`, `bash-safe`)
 - **`pattern`** — a regex matched against Bash commands or file paths
 
+### Path matching is case-insensitive by default
+
+macOS filesystems are case-insensitive — `.ENV` and `.env` are the same file — so exact-case
+matching would let casing bypass every path-based rule. All `paths` globs on filesystem
+operations (`read-path`, `write-path`, `write-content`, `delete-path`) therefore match
+case-insensitively. A rule can opt out with `"case-sensitive": true`.
+
 ## Adding a New Rule
 
 1. Add the rule to `rules.json` with a unique `description`

--- a/hooks/PreToolUse/engine/operations/filesystem.py
+++ b/hooks/PreToolUse/engine/operations/filesystem.py
@@ -76,12 +76,21 @@ def _python_open_paths(command: str) -> list[str]:
     return re.findall(r"""open\s*\(\s*['"]([^'"]+)['"]""", command)
 
 
+def _rule_ignore_case(rule: dict) -> bool:
+    """Path matching is case-insensitive unless the rule sets "case-sensitive": true."""
+    return not rule.get("case-sensitive", False)
+
+
 def _any_path_matches(
-    paths: list[str], rule_paths: list[str], repo_root: str | None, cwd: str
+    paths: list[str],
+    rule_paths: list[str],
+    repo_root: str | None,
+    cwd: str,
+    ignore_case: bool = True,
 ) -> bool:
     for p in paths:
         for pattern in rule_paths:
-            if matches_path_pattern(p, pattern, repo_root, cwd):
+            if matches_path_pattern(p, pattern, repo_root, cwd, ignore_case=ignore_case):
                 return True
     return False
 
@@ -90,10 +99,11 @@ def matches_read_path(payload: dict, rule: dict, repo_root: str | None, cwd: str
     tool_name = payload.get("tool_name", "")
     tool_input = payload.get("tool_input", {})
     rule_paths = rule.get("paths", [])
+    ignore_case = _rule_ignore_case(rule)
 
     if tool_name == "Read":
         fp = tool_input.get("file_path", "")
-        return _any_path_matches([fp], rule_paths, repo_root, cwd)
+        return _any_path_matches([fp], rule_paths, repo_root, cwd, ignore_case)
 
     if tool_name == "Bash":
         command = tool_input.get("command", "")
@@ -111,7 +121,7 @@ def matches_read_path(payload: dict, rule: dict, repo_root: str | None, cwd: str
         for m in re.finditer(r"<\s*([^\s;|&<>]+)", command):
             candidates.append(m.group(1))
 
-        return _any_path_matches(candidates, rule_paths, repo_root, cwd)
+        return _any_path_matches(candidates, rule_paths, repo_root, cwd, ignore_case)
 
     return False
 
@@ -120,14 +130,15 @@ def matches_write_path(payload: dict, rule: dict, repo_root: str | None, cwd: st
     tool_name = payload.get("tool_name", "")
     tool_input = payload.get("tool_input", {})
     rule_paths = rule.get("paths", [])
+    ignore_case = _rule_ignore_case(rule)
 
     if tool_name == "Edit":
         fp = tool_input.get("file_path", "")
-        return _any_path_matches([fp], rule_paths, repo_root, cwd)
+        return _any_path_matches([fp], rule_paths, repo_root, cwd, ignore_case)
 
     if tool_name == "Write":
         fp = tool_input.get("file_path", "")
-        return _any_path_matches([fp], rule_paths, repo_root, cwd)
+        return _any_path_matches([fp], rule_paths, repo_root, cwd, ignore_case)
 
     if tool_name == "Bash":
         command = tool_input.get("command", "")
@@ -148,7 +159,7 @@ def matches_write_path(payload: dict, rule: dict, repo_root: str | None, cwd: st
 
         candidates.extend(_redirect_targets(command))
 
-        return _any_path_matches(candidates, rule_paths, repo_root, cwd)
+        return _any_path_matches(candidates, rule_paths, repo_root, cwd, ignore_case)
 
     return False
 
@@ -182,7 +193,7 @@ def matches_write_content(payload: dict, rule: dict, repo_root: str | None, cwd:
     else:
         return False
 
-    if not _any_path_matches([fp], rule_paths, repo_root, cwd):
+    if not _any_path_matches([fp], rule_paths, repo_root, cwd, _rule_ignore_case(rule)):
         return False
 
     for pattern in content_patterns:
@@ -210,4 +221,4 @@ def matches_delete_path(payload: dict, rule: dict, repo_root: str | None, cwd: s
         if cmd in _DELETE_COMMANDS:
             candidates.extend(_path_args(tokens))
 
-    return _any_path_matches(candidates, rule_paths, repo_root, cwd)
+    return _any_path_matches(candidates, rule_paths, repo_root, cwd, _rule_ignore_case(rule))

--- a/hooks/PreToolUse/engine/resolver.py
+++ b/hooks/PreToolUse/engine/resolver.py
@@ -38,7 +38,13 @@ def normalize_path(path: str, cwd: str | None = None) -> str:
     return os.path.abspath(expanded)
 
 
-def matches_path_pattern(file_path: str, pattern: str, repo_root: str | None, cwd: str) -> bool:
+def matches_path_pattern(
+    file_path: str,
+    pattern: str,
+    repo_root: str | None,
+    cwd: str,
+    ignore_case: bool = True,
+) -> bool:
     """
     Match a file path against a rule pattern.
 
@@ -47,20 +53,26 @@ def matches_path_pattern(file_path: str, pattern: str, repo_root: str | None, cw
 
     Unanchored patterns (**/.env, *.key):
       Resolved relative to repo_root (or cwd if not in a repo).
+
+    Matching is case-insensitive by default — macOS filesystems are
+    case-insensitive, so `.ENV` and `.env` are the same file and exact-case
+    matching would be a bypass vector. Rules opt out with "case-sensitive": true,
+    which arrives here as ignore_case=False.
     """
     resolved = normalize_path(file_path, cwd)
 
     if pattern.startswith("~"):
-        expanded = str(Path(pattern).expanduser())
-        return _glob_match(resolved, expanded)
+        full_pattern = str(Path(pattern).expanduser())
+    elif pattern.startswith("/"):
+        full_pattern = pattern
+    else:
+        base = repo_root or cwd
+        if not base:
+            return False
+        full_pattern = str(Path(base) / pattern)
 
-    if pattern.startswith("/"):
-        return _glob_match(resolved, pattern)
-
-    base = repo_root or cwd
-    if not base:
-        return False
-    full_pattern = str(Path(base) / pattern)
+    if ignore_case:
+        return _glob_match(resolved.lower(), full_pattern.lower())
     return _glob_match(resolved, full_pattern)
 
 

--- a/hooks/PreToolUse/rules.json
+++ b/hooks/PreToolUse/rules.json
@@ -34,6 +34,16 @@
       "reason": "Env files may contain secrets — read environment values another way or ask the user"
     },
     {
+      "id": "block-secret-file-reads",
+      "description": "Block reading files with secret in the name — likely credentials",
+      "operation": "read-path",
+      "paths": [
+        "/**/*secret*"
+      ],
+      "action": "deny",
+      "reason": "Files with 'secret' in the name likely contain credentials — ask the user to provide values another way"
+    },
+    {
       "id": "block-keychain-reads",
       "description": "Block reading macOS Keychain files",
       "operation": "read-path",

--- a/hooks/PreToolUse/tests/operations/test_filesystem.py
+++ b/hooks/PreToolUse/tests/operations/test_filesystem.py
@@ -199,3 +199,47 @@ class TestCompoundCommands:
     def test_safe_compound_no_match(self):
         p = bash("git status && echo done")
         assert matches_read_path(p, self.SSH_RULE, None, REPO) is False
+
+
+# ---------------------------------------------------------------------------
+# Case sensitivity: insensitive by default, "case-sensitive": true opts out
+# ---------------------------------------------------------------------------
+
+
+class TestCaseSensitivity:
+    SECRET_RULE = {
+        "paths": ["/**/*secret*"],
+        "action": "deny",
+    }
+
+    SECRET_RULE_SENSITIVE = {
+        "paths": ["/**/*secret*"],
+        "case-sensitive": True,
+        "action": "deny",
+    }
+
+    def test_read_matches_other_casing_by_default(self):
+        p = read_tool(f"{REPO}/ClientSECRET.json")
+        assert matches_read_path(p, self.SECRET_RULE, REPO, REPO) is True
+
+    def test_bash_read_matches_other_casing_by_default(self):
+        p = bash(f"cat {REPO}/PROD_Secrets.txt")
+        assert matches_read_path(p, self.SECRET_RULE, REPO, REPO) is True
+
+    def test_case_sensitive_rule_requires_exact_case(self):
+        p = read_tool(f"{REPO}/ClientSECRET.json")
+        assert matches_read_path(p, self.SECRET_RULE_SENSITIVE, REPO, REPO) is False
+
+    def test_case_sensitive_rule_still_matches_exact_case(self):
+        p = read_tool(f"{REPO}/client-secret.json")
+        assert matches_read_path(p, self.SECRET_RULE_SENSITIVE, REPO, REPO) is True
+
+    def test_write_matches_other_casing_by_default(self):
+        rule = {"paths": [f"{HOME}/.ssh/*"], "action": "deny"}
+        p = write_tool(f"{HOME}/.SSH/id_rsa")
+        assert matches_write_path(p, rule, None, REPO) is True
+
+    def test_delete_matches_other_casing_by_default(self):
+        rule = {"paths": [f"{HOME}/.ssh/*"], "action": "deny"}
+        p = bash(f"rm {HOME}/.SSH/id_rsa")
+        assert matches_delete_path(p, rule, None, REPO) is True

--- a/hooks/PreToolUse/tests/rules/test_block-reading-files-with-secret-in-the-name.py
+++ b/hooks/PreToolUse/tests/rules/test_block-reading-files-with-secret-in-the-name.py
@@ -1,0 +1,82 @@
+"""Tests for rule: Block reading files with secret in the name."""
+
+from engine import evaluate
+
+REPO = "/repo/myproject"
+
+RULE_DESCRIPTION = "Block reading files with secret in the name — likely credentials"
+RULE_ID = "block-secret-file-reads"
+
+
+def _payload(tool_name, tool_input, cwd=REPO):
+    return {"tool_name": tool_name, "tool_input": tool_input, "cwd": cwd}
+
+
+def test_match(rule):
+    """Read tool on a secrets file is denied."""
+    payload = _payload("Read", {"file_path": f"{REPO}/config/secrets.yaml"})
+    result = evaluate(payload, [rule], repo_root=REPO)
+    assert result["decision"] == "deny"
+
+
+def test_no_match(rule):
+    """Read tool on an unrelated file is not denied."""
+    payload = _payload("Read", {"file_path": f"{REPO}/main.py"})
+    result = evaluate(payload, [rule], repo_root=REPO)
+    assert result["decision"] == "proceed"
+
+
+def test_boundary_secret_as_substring(rule):
+    """'secret' anywhere in the file name is denied (e.g. client-secret.json)."""
+    payload = _payload("Read", {"file_path": f"{REPO}/auth/client-secret.json"})
+    result = evaluate(payload, [rule], repo_root=REPO)
+    assert result["decision"] == "deny"
+
+
+def test_boundary_capitalized_secret(rule):
+    """Capitalized 'Secret' in the file name is denied (e.g. ClientSecret.json)."""
+    payload = _payload("Read", {"file_path": f"{REPO}/auth/ClientSecret.json"})
+    result = evaluate(payload, [rule], repo_root=REPO)
+    assert result["decision"] == "deny"
+
+
+def test_boundary_uppercase_secret(rule):
+    """All-caps 'SECRET' in the file name is denied."""
+    payload = _payload("Read", {"file_path": f"{REPO}/PROD_SECRETS.txt"})
+    result = evaluate(payload, [rule], repo_root=REPO)
+    assert result["decision"] == "deny"
+
+
+def test_boundary_mixed_case_secret(rule):
+    """Arbitrary casing is denied — path matching is case-insensitive by default."""
+    payload = _payload("Read", {"file_path": f"{REPO}/SeCrEtS.txt"})
+    result = evaluate(payload, [rule], repo_root=REPO)
+    assert result["decision"] == "deny"
+
+
+def test_boundary_outside_repo_blocked(rule):
+    """Secret files OUTSIDE the repo are also denied — the pattern is filesystem-anchored."""
+    payload = _payload("Read", {"file_path": "/Users/someone/Documents/secrets.txt"})
+    result = evaluate(payload, [rule], repo_root=REPO)
+    assert result["decision"] == "deny"
+
+
+def test_boundary_secret_directory_not_blocked(rule):
+    """A file INSIDE a secrets/ directory is not blocked unless its own name matches."""
+    payload = _payload("Read", {"file_path": f"{REPO}/secrets/readme.md"})
+    result = evaluate(payload, [rule], repo_root=REPO)
+    assert result["decision"] == "proceed"
+
+
+def test_boundary_bash_cat(rule):
+    """cat of a secret file via Bash is denied."""
+    payload = _payload("Bash", {"command": f"cat {REPO}/k8s/api-secret.yaml"})
+    result = evaluate(payload, [rule], repo_root=REPO)
+    assert result["decision"] == "deny"
+
+
+def test_boundary_bash_grep(rule):
+    """grep over a secret file via Bash is denied."""
+    payload = _payload("Bash", {"command": f"grep -i token {REPO}/secrets.env"})
+    result = evaluate(payload, [rule], repo_root=REPO)
+    assert result["decision"] == "deny"

--- a/hooks/PreToolUse/tests/test_resolver.py
+++ b/hooks/PreToolUse/tests/test_resolver.py
@@ -145,6 +145,31 @@ def test_unanchored_envrc_matches():
 
 
 # ---------------------------------------------------------------------------
+# matches_path_pattern: case sensitivity
+# ---------------------------------------------------------------------------
+
+
+def test_case_insensitive_by_default():
+    """Matching ignores case by default — .ENV is the same file as .env on macOS."""
+    assert matches_path_pattern(f"{REPO}/.ENV", "**/.env", REPO, "") is True
+
+
+def test_case_insensitive_pattern_side():
+    """Case-insensitivity applies to the pattern side too."""
+    assert matches_path_pattern(f"{REPO}/secrets.yaml", "**/*SECRET*", REPO, "") is True
+
+
+def test_case_insensitive_mixed_case():
+    assert matches_path_pattern(f"{REPO}/SeCrEtS.txt", "/**/*secret*", REPO, "") is True
+
+
+def test_case_sensitive_opt_out():
+    """ignore_case=False restores exact-case matching."""
+    assert matches_path_pattern(f"{REPO}/.ENV", "**/.env", REPO, "", ignore_case=False) is False
+    assert matches_path_pattern(f"{REPO}/.env", "**/.env", REPO, "", ignore_case=False) is True
+
+
+# ---------------------------------------------------------------------------
 # normalize_path: cwd-aware resolution
 # ---------------------------------------------------------------------------
 

--- a/templates/user-claude.md
+++ b/templates/user-claude.md
@@ -111,6 +111,13 @@ Plans live outside the repo in your configured work folder (`~/.claude/agent-ski
   authorization that requires those specific words -- not "ship it", "land it", or other shorthand.
 - **Batch commits before pushing** -- every push triggers CI and jobs do not self-cancel.
   Accumulate all changes locally, then push once when the work is ready for review.
+- **`--no-verify` has exactly one sanctioned use: merge commits carrying wholly
+  unrelated incoming changes.** Pre-commit hooks (lint-staged) choke on large merge
+  commits -- typed lint over a huge staged set OOMs or emits spurious warnings on the
+  incoming files. When (a) it is a merge commit, (b) the incoming changes are someone
+  else's and already green on their branch, and (c) any conflict resolutions kept
+  already-hook-verified content, `--no-verify` is acceptable. Every other use remains
+  forbidden; this exception never applies to ordinary commits of your own changes.
 
 ## Never Pipe State-Changing Commands Through Filters
 

--- a/templates/user-claude.md
+++ b/templates/user-claude.md
@@ -16,7 +16,7 @@ stale comments, broken checks, or an obvious improvement, the right question is 
 not **"would a human squeeze this in?"**.
 
 When deciding whether to pick something up, reframe:
-**"I CAN definitely do this now, and I'm already here."** 
+**"I CAN definitely do this now, and I'm already here."**
 The answer is almost always that you can and should improve/fix when it is an unambiguous improvement or fixing a real issue.
 
 ## Slash Commands Are Skill Invocations
@@ -52,14 +52,14 @@ untrackable dependency on local state that undermines the goal of a repeatable C
 
 **Before saving anything, ask: where does this belong?**
 
-| Type of content | Where it goes |
-|---|---|
-| Behavioral guidance, ways of working | `templates/user-claude.md` or `templates/<username>.md` |
-| Project-wide conventions, rules, standards | `<repo>/.claude/rules/<topic>.md` |
-| Project orientation (structure, build, test) | `<repo>/CLAUDE.md` |
-| In-progress work, task breakdown | Tasks tool (current session only) |
-| Implementation plans | `<work-folder>/<slug>/plan.md` — work folder is set in `~/.claude/agent-skills.json` (`work_root`) |
-| Active bug / short-lived project state | Auto-memory is acceptable, but prefer a note in your work folder |
+| Type of content                              | Where it goes                                                                                      |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Behavioral guidance, ways of working         | `templates/user-claude.md` or `templates/<username>.md`                                            |
+| Project-wide conventions, rules, standards   | `<repo>/.claude/rules/<topic>.md`                                                                  |
+| Project orientation (structure, build, test) | `<repo>/CLAUDE.md`                                                                                 |
+| In-progress work, task breakdown             | Tasks tool (current session only)                                                                  |
+| Implementation plans                         | `<work-folder>/<slug>/plan.md` — work folder is set in `~/.claude/agent-skills.json` (`work_root`) |
+| Active bug / short-lived project state       | Auto-memory is acceptable, but prefer a note in your work folder                                   |
 
 **Almost nothing should go into auto-memory.** If it's a pattern, preference, or lesson that should
 survive a `git clone` on a new machine — it belongs in the repo. Run `bash setup.sh` to deploy
@@ -99,7 +99,7 @@ you discover new information.
 Plans live outside the repo in your configured work folder (`~/.claude/agent-skills.json` → `work_root`, defaulting to `~/Work`). This keeps them alive across branch deletions and accessible from any repo.
 
 - **Keep plans current as work progresses.** A plan that reflects reality lets any new agent session pick up right where the last one left off — no re-discovery, no surprises about what's done or not. Update phase and task status as you complete them, not just at the end.
-- PRs are the permanent record of *what was done and why* (git blame → PR → ticket). Plans are the *working state* — update them, don't treat them as archival.
+- PRs are the permanent record of _what was done and why_ (git blame → PR → ticket). Plans are the _working state_ — update them, don't treat them as archival.
 - The PR creation step (in /do-work) captures key decisions in the PR description.
 
 ## Working with git/gh
@@ -111,6 +111,27 @@ Plans live outside the repo in your configured work folder (`~/.claude/agent-ski
   authorization that requires those specific words -- not "ship it", "land it", or other shorthand.
 - **Batch commits before pushing** -- every push triggers CI and jobs do not self-cancel.
   Accumulate all changes locally, then push once when the work is ready for review.
+
+## Never Pipe State-Changing Commands Through Filters
+
+Piping `git commit`, `git push`, or any hook-running/state-changing command through
+`tail`/`grep`/`head` replaces the command's exit code with the filter's. A failed
+pre-commit hook then reads as success, `&&` chains keep going, and the failure surfaces
+later as a mystery (e.g. a push that silently lacked the commit it was supposed to carry).
+The same applies to any command whose exit code feeds a verification decision
+(`turbo run test | tail` hides a red suite behind tail's exit 0).
+
+- **State-changing or verification commands run bare.** Success output is short;
+  failure output is exactly what you need to see.
+- If output volume genuinely matters, keep the exit code honest -- redirect to a file,
+  show the tail on success, dump everything on failure:
+
+  ```bash
+  git commit -m "..." >/tmp/commit.log 2>&1 && tail -2 /tmp/commit.log || { cat /tmp/commit.log; false; }
+  ```
+
+- Filtering remains fine for read-only commands where the exit code is unused
+  (`git log | head`, `grep | sort`).
 
 ## Scaling Large Operations
 
@@ -134,7 +155,7 @@ context-dependent fixes), coordinate as a hub and delegate to parallel sub-agent
 2. **Use the cheapest model that can handle the task.** Haiku for mechanical transforms, Sonnet
    for anything requiring understanding. Reserve Opus for genuinely hard judgment calls.
 3. **Scope each agent tightly.** One task, one clear deliverable. Tell each agent exactly which
-   files to read and which to write. Specify what it should *not* do — no running tests, no
+   files to read and which to write. Specify what it should _not_ do — no running tests, no
    lint fixes, no exploration beyond the stated scope.
 4. **Separate reads from writes.** Discovery agents get read-only instructions. Authoring agents
    get a precise spec and write to specific files. Mixing the two leads to agents wandering.
@@ -254,7 +275,7 @@ context by only loading when relevant.
 
 ### Verify the Full End-to-End Outcome
 
-The goal is to verify what the actual *consumer* of the work would experience — not just that the
+The goal is to verify what the actual _consumer_ of the work would experience — not just that the
 technical artifact you produced exists or passed an isolated check. Who that consumer is depends on
 context: an end user opening a deployed app, a developer running a scaffolded project's own scripts,
 an analyst querying a pipeline's output dataset, a downstream team importing a published package.
@@ -269,24 +290,24 @@ files exist, that individual steps exited 0, that a health endpoint returns 200 
 integration mismatches that only appear when the system is exercised end-to-end the way it's
 actually used.
 
-**Upfront success criteria.** For complex multi-step tasks, list what "done" looks like *before*
+**Upfront success criteria.** For complex multi-step tasks, list what "done" looks like _before_
 starting and confirm it matches expectations. This prevents the incremental-reveal pattern where
 each round of checking uncovers another unchecked layer.
 
 **Examples across different problem domains:**
 
-- *Deployed web + API + database:* The page renders real content → the frontend reaches the API →
+- _Deployed web + API + database:_ The page renders real content → the frontend reaches the API →
   the API returns live database rows → seed data is present. "Service is RUNNING" is not done.
 
-- *Scaffolded project template:* The generated project's own scripts (`install`, `build`, `test`)
+- _Scaffolded project template:_ The generated project's own scripts (`install`, `build`, `test`)
   all succeed end-to-end. Independently checking that expected files exist can miss wiring issues
   between scaffolded pieces — verify using the same commands the developer would actually run.
 
-- *Data pipeline:* The output dataset contains the expected rows for known inputs — not just that
+- _Data pipeline:_ The output dataset contains the expected rows for known inputs — not just that
   each transformation step exited 0. A pipeline can complete cleanly while producing empty or
   malformed output if an upstream join silently drops records.
 
-- *Published package or library:* A fresh install in a new project can import the package and call
+- _Published package or library:_ A fresh install in a new project can import the package and call
   its exports. Build artifacts in `dist/` existing is not the same as the package being consumable
   downstream — the `exports` map, `main` field, or peer dep resolution may still be broken.
 
@@ -294,15 +315,15 @@ each round of checking uncovers another unchecked layer.
 
 These commands will be blocked -- avoid generating them and use alternatives instead:
 
-| Blocked                                  | Reason               | Alternative                          |
-| ---------------------------------------- | -------------------- | ------------------------------------ |
-| `curl \| bash`, `wget \| sh`, etc.       | Pipe-to-shell        | Download script, inspect, then run   |
-| `sudo`, `su`, `doas`                     | Privilege escalation | Ask user to run manually             |
-| `eval`, `exec`                           | Arbitrary execution  | Rewrite without dynamic eval         |
-| `ssh`, `scp`, `sftp`                     | Remote execution     | Ask user to run manually             |
-| `dd`, `shred`, `fdisk`, `parted`, `mkfs` | Disk destruction     | Ask user to run manually             |
-| `nc`, `netcat`, `ncat`                   | Network listener     | Use `curl`/`wget` for outbound       |
-| `security`                               | Keychain access      | Ask user to run manually             |
+| Blocked                                  | Reason               | Alternative                        |
+| ---------------------------------------- | -------------------- | ---------------------------------- |
+| `curl \| bash`, `wget \| sh`, etc.       | Pipe-to-shell        | Download script, inspect, then run |
+| `sudo`, `su`, `doas`                     | Privilege escalation | Ask user to run manually           |
+| `eval`, `exec`                           | Arbitrary execution  | Rewrite without dynamic eval       |
+| `ssh`, `scp`, `sftp`                     | Remote execution     | Ask user to run manually           |
+| `dd`, `shred`, `fdisk`, `parted`, `mkfs` | Disk destruction     | Ask user to run manually           |
+| `nc`, `netcat`, `ncat`                   | Network listener     | Use `curl`/`wget` for outbound     |
+| `security`                               | Keychain access      | Ask user to run manually           |
 
 ## CRITICAL -- NEVER IGNORE OR BYPASS
 


### PR DESCRIPTION
## Summary

Two related hardening changes to the PreToolUse hook engine, plus a couple of guidance tweaks that rode along.

### Block reading files with `secret` in the name

New deny rule `block-secret-file-reads`: any file whose **name** contains `secret` is blocked from the Read tool and bash read commands (`cat`, `grep`, etc.).

- Filesystem-anchored (`/**/*secret*`) — covers files outside the repo too, unlike the repo-relative `.env` rule
- Matches the file's own name only; `secrets/readme.md` inside a `secrets/` dir is not blocked

### Path matching is now case-insensitive by default

While adding the rule we realized exact-case glob matching was a bypass vector: macOS filesystems are case-insensitive, so `cat .ENV` opened the same file as `.env` but sailed past `block-env-reads`. All path-based operations (`read-path`, `write-path`, `write-content`, `delete-path`) now match case-insensitively, which retroactively closes the casing bypass on every existing path rule (`.ENV`, `~/.SSH/*`, keychain paths, …). Rules can opt out with `"case-sensitive": true` (none currently do).

### Guidance tweaks (separate commits)

- `templates/user-claude.md`: never pipe state-changing commands through filters (exit-code masking)
- `templates/user-claude.md`: sanction `--no-verify` for merge commits carrying unrelated incoming changes

## Verification

### Hooks (PreToolUse)
- [x] Manually triggered the hook rule and confirmed it fires correctly (deny/ask/allow) — staged the engine + rules in `/tmp` and ran payloads through the real `pre-tool-use.sh` entry point: secret-file reads denied (multiple casings, Read + bash `cat`), and `.ENV` now denied by the existing env rule
- [x] Confirmed non-matching cases pass through (no false positives) — `main.py` reads and commands merely mentioning "secret" (`git log --grep secret`) are allowed
- [x] `cd hooks/PreToolUse && uvx pytest tests/ -v` — all 480 passing (includes new rule-convention tests, resolver case tests, and operations-level opt-out threading tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)