### PR TITLE
Personal machine-local setup: rules overlay + macOS Notification hook

### DIFF
--- a/hooks/Notification/focus-claude-session.sh
+++ b/hooks/Notification/focus-claude-session.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Click handler for Claude attention notifications (notify-attention.sh).
+# Brings the window hosting the given session directory to the front.
+#
+# Usage:
+#   focus-claude-session.sh vscode <workspace-root> [bundle-id]
+#   focus-claude-session.sh ghostty <session-cwd> [workspace-root]
+#
+# Runs in terminal-notifier's context on click, so it must not assume
+# the session's environment (PATH, cwd) and macOS attributes its
+# Automation permission to terminal-notifier.
+
+set -u
+PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+
+mode=${1:?mode}
+shift
+
+canonical() {
+  realpath "$1" 2>/dev/null || printf '%s' "$1"
+}
+
+focus_vscode() {
+  local dir=${1:?dir} bundle=${2:-com.microsoft.VSCode}
+  # Opening a folder that is already open focuses its existing window.
+  open -b "$bundle" "$dir"
+}
+
+focus_ghostty() {
+  local dir target root match="" fallback="" line tid twd
+  dir=${1:?dir}
+  target=$(canonical "$dir")
+  root=$(canonical "${2:-$dir}")
+
+  # Ghostty reports working directories as the shell announced them
+  # (possibly via a symlinked path), so canonicalize before comparing.
+  while IFS='|' read -r tid twd; do
+    [ -n "$tid" ] && [ -n "$twd" ] || continue
+    twd=$(canonical "$twd")
+    if [ "$twd" = "$target" ]; then
+      match=$tid
+      break
+    fi
+    if [ -z "$fallback" ] && [ "$twd" = "$root" ]; then
+      fallback=$tid
+    fi
+  done < <(osascript -e 'tell application "Ghostty"
+    set out to ""
+    repeat with t in terminals
+      try
+        set out to out & (id of t) & "|" & (working directory of t) & linefeed
+      end try
+    end repeat
+    return out
+  end tell')
+
+  [ -n "$match" ] || match=$fallback
+  if [ -n "$match" ]; then
+    osascript \
+      -e "tell application \"Ghostty\" to focus terminal id \"$match\"" \
+      -e 'tell application "Ghostty" to activate'
+  else
+    open -b com.mitchellh.ghostty
+  fi
+}
+
+case "$mode" in
+  vscode) focus_vscode "$@" ;;
+  ghostty) focus_ghostty "$@" ;;
+  *)
+    echo "unknown mode: $mode" >&2
+    exit 1
+    ;;
+esac

--- a/hooks/Notification/notify-attention.sh
+++ b/hooks/Notification/notify-attention.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Notification hook entry point.
+#
+# Registered in ~/.claude/settings.json hooks.Notification.
+# Shows a clickable macOS banner when Claude needs attention. Clicking
+# focuses the window hosting this session: Ghostty notifications are
+# emitted by the session's own terminal surface (exact tab focus),
+# VS Code clicks open the workspace folder (focuses its existing
+# window), and Superset-managed sessions activate the Superset app.
+#
+# Non-Ghostty paths require terminal-notifier
+# (brew install terminal-notifier).
+
+set -u
+
+input=$(cat 2>/dev/null || true)
+msg=$(printf '%s' "$input" | jq -r '.message // empty' 2>/dev/null) || msg=""
+[ -n "$msg" ] || msg="Claude needs your attention"
+cwd=$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null) || cwd=""
+[ -n "$cwd" ] || cwd="$PWD"
+
+# The workspace/worktree root is what editors open as a window; fall
+# back to the raw cwd outside a git checkout.
+root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null) || root="$cwd"
+
+# The hook runs detached from any tty, so walk up the process tree to
+# the session's controlling terminal.
+find_session_tty() {
+  local pid=$$ tty_name
+  while [ -n "$pid" ] && [ "$pid" -gt 1 ]; do
+    tty_name=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    if [ -n "$tty_name" ] && [ "$tty_name" != "??" ]; then
+      printf '/dev/%s' "$tty_name"
+      return 0
+    fi
+    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+  done
+  return 1
+}
+
+# Ghostty ties an OSC 777 notification to the surface that emits it,
+# so clicking the banner focuses this session's exact tab — no
+# directory matching and no Automation permission needed. Ghostty
+# suppresses it when the surface is already focused.
+notify_ghostty_native() {
+  local tty_dev
+  tty_dev=$(find_session_tty) || return 1
+  [ -w "$tty_dev" ] || return 1
+  printf '\033]777;notify;Claude Code — %s;%s\033\\' \
+    "$(basename "$root")" "$(printf '%s' "$msg" | tr -d '\000-\037')" \
+    >"$tty_dev"
+}
+
+if [ "${TERM_PROGRAM:-}" = "ghostty" ] && notify_ghostty_native; then
+  exit 0
+fi
+
+notifier=$(command -v terminal-notifier || true)
+[ -n "$notifier" ] && [ -x "$notifier" ] || exit 0
+
+focus="$HOME/.claude/hooks/focus-claude-session.sh"
+common=(-title "Claude Code" -subtitle "$(basename "$root")" \
+  -message "$msg" -sound Ping -group "claude-attention-$root")
+
+case "${TERM_PROGRAM:-}" in
+  vscode)
+    bundle="${__CFBundleIdentifier:-com.microsoft.VSCode}"
+    "$notifier" "${common[@]}" \
+      -execute "$focus vscode $(printf '%q' "$root") $(printf '%q' "$bundle")"
+    ;;
+  ghostty)
+    "$notifier" "${common[@]}" \
+      -execute "$focus ghostty $(printf '%q' "$cwd") $(printf '%q' "$root")"
+    ;;
+  *)
+    if [ -n "${SUPERSET_HOME_DIR:-}" ] ||
+      [ "${__CFBundleIdentifier:-}" = "com.superset.desktop" ]; then
+      # -sender fakes the posting app, so a click activates Superset;
+      # -execute/-open are ignored when -sender is set.
+      "$notifier" "${common[@]}" -sender com.superset.desktop
+    elif [ -n "${__CFBundleIdentifier:-}" ]; then
+      "$notifier" "${common[@]}" -activate "$__CFBundleIdentifier"
+    else
+      "$notifier" "${common[@]}"
+    fi
+    ;;
+esac
+
+exit 0

--- a/hooks/PreToolUse/CLAUDE.md
+++ b/hooks/PreToolUse/CLAUDE.md
@@ -31,6 +31,7 @@ All rules are evaluated against every tool call. The highest-priority match wins
 ## Rule Types
 
 Rules in `rules.json` match by either:
+
 - **`operation`** — a named operation handler (e.g. `read-path`, `git-force-push`, `bash-safe`)
 - **`pattern`** — a regex matched against Bash commands or file paths
 
@@ -49,6 +50,36 @@ case-insensitively. A rule can opt out with `"case-sensitive": true`.
 4. Run `uvx pytest hooks/PreToolUse/tests/` — the convention checker will catch missing tests
 
 Slug derivation: lowercase, hyphens, truncated at first `—` or `(`.
+
+## Personal machine-local overlay
+
+`~/.agent-skills/local-rules.json` is a personal, uncommitted source of
+**additive** rules, merged into the global set at evaluation time
+(`load_user_local_rules` in `engine.py`, wired in `interpreter.py`). Use it for
+private rules — e.g. org- or employer-specific command blocks — that should not
+live in this shared repo. The file mirrors the per-repo override shape, but its
+entries are full rule objects rather than relax-only overrides:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": {
+      "rules": [
+        {
+          "id": "lc-block-prod-aws-profile",
+          "pattern": "(?:--profile[=\\s]+|AWS_PROFILE=)production-",
+          "action": "deny",
+          "reason": "prod access is human-initiated only"
+        }
+      ]
+    }
+  }
+}
+```
+
+Overlay rules are exempt from the `rules.json` convention checker (they are not
+in this repo) and fail open if the file is absent or malformed. Distinct from
+the per-repo `.agent-skills/config.json`, which only _relaxes_ existing denies.
 
 ## Testing
 

--- a/hooks/PreToolUse/engine/engine.py
+++ b/hooks/PreToolUse/engine/engine.py
@@ -32,6 +32,32 @@ def _load_repo_config(repo_root: str | None) -> dict | None:
     return config
 
 
+USER_LOCAL_RULES_PATH = os.path.expanduser("~/.agent-skills/local-rules.json")
+
+
+def load_user_local_rules(path: str = USER_LOCAL_RULES_PATH) -> list:
+    """Load additive PreToolUse rules from a personal, machine-local overlay.
+
+    Lets a user enforce private rules (e.g. org- or employer-specific blocks)
+    without committing them to the shared agent-skills repo. The file mirrors
+    the .agent-skills/config.json shape:
+    {"hooks": {"PreToolUse": {"rules": [ <full rule objects> ]}}}.
+    Each entry is a complete rule (pattern/operation + action + reason) and is
+    merged into the global rule set, so deny/ask/allow priority applies as usual.
+
+    Fails open (returns []) when the file is absent or malformed — a broken
+    personal overlay must never break every tool call, matching the fail-open
+    posture of _load_repo_config and the entry script.
+    """
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return []
+    rules = data.get("hooks", {}).get("PreToolUse", {}).get("rules", [])
+    return rules if isinstance(rules, list) else []
+
+
 def _get_rule_overrides(config: dict | None, rule_id: str | None) -> dict | None:
     """Get per-repo overrides for a specific rule by id."""
     if config is None or rule_id is None:

--- a/hooks/PreToolUse/engine/interpreter.py
+++ b/hooks/PreToolUse/engine/interpreter.py
@@ -14,7 +14,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 from resolver import resolve_repo_root
 
-from engine import evaluate
+from engine import evaluate, load_user_local_rules
 
 HOOK_RULES_PATH = Path(__file__).parent.parent / "hook-rules.json"
 
@@ -29,7 +29,7 @@ def main() -> None:
     payload = json.loads(sys.stdin.read())
     cwd = payload.get("cwd", "")
 
-    rules = load_hook_rules()
+    rules = load_hook_rules() + load_user_local_rules()
     repo_root = resolve_repo_root(cwd)
 
     result = evaluate(payload, rules, repo_root=repo_root)

--- a/hooks/PreToolUse/tests/test_user_local_rules.py
+++ b/hooks/PreToolUse/tests/test_user_local_rules.py
@@ -1,0 +1,64 @@
+"""Tests for the personal machine-local rule overlay (load_user_local_rules)."""
+
+import json
+
+from engine import evaluate, load_user_local_rules
+
+_SAMPLE_RULE = {
+    "id": "user-block-example",
+    "description": "Block an example command",
+    "pattern": "do-not-run-me",
+    "action": "deny",
+    "reason": "blocked by personal overlay",
+}
+
+
+def _write_overlay(path, rules):
+    path.write_text(json.dumps({"hooks": {"PreToolUse": {"rules": rules}}}))
+
+
+def _bash(command, cwd="/repo"):
+    return {"tool_name": "Bash", "tool_input": {"command": command}, "cwd": cwd}
+
+
+def test_loads_rules_from_file(tmp_path):
+    """Rules nested under hooks.PreToolUse.rules are returned."""
+    overlay = tmp_path / "local-rules.json"
+    _write_overlay(overlay, [_SAMPLE_RULE])
+    assert load_user_local_rules(str(overlay)) == [_SAMPLE_RULE]
+
+
+def test_missing_file_returns_empty(tmp_path):
+    """An absent overlay file yields no rules (fail open)."""
+    assert load_user_local_rules(str(tmp_path / "nope.json")) == []
+
+
+def test_malformed_json_returns_empty(tmp_path):
+    """Malformed JSON yields no rules rather than raising (fail open)."""
+    overlay = tmp_path / "local-rules.json"
+    overlay.write_text("{ not valid json")
+    assert load_user_local_rules(str(overlay)) == []
+
+
+def test_missing_nested_keys_returns_empty(tmp_path):
+    """A file without the hooks.PreToolUse.rules path yields no rules."""
+    overlay = tmp_path / "local-rules.json"
+    overlay.write_text(json.dumps({"hooks": {}}))
+    assert load_user_local_rules(str(overlay)) == []
+
+
+def test_non_list_rules_returns_empty(tmp_path):
+    """A non-list rules value is ignored."""
+    overlay = tmp_path / "local-rules.json"
+    overlay.write_text(json.dumps({"hooks": {"PreToolUse": {"rules": "oops"}}}))
+    assert load_user_local_rules(str(overlay)) == []
+
+
+def test_overlay_rule_denies_via_evaluate(tmp_path):
+    """An overlay deny rule, merged into the rule set, blocks a matching command."""
+    overlay = tmp_path / "local-rules.json"
+    _write_overlay(overlay, [_SAMPLE_RULE])
+    rules = load_user_local_rules(str(overlay))
+    result = evaluate(_bash("do-not-run-me --now"), rules)
+    assert result["decision"] == "deny"
+    assert result["reason"] == "blocked by personal overlay"

--- a/setup.sh
+++ b/setup.sh
@@ -319,7 +319,66 @@ else
 fi
 
 # --------------------------------------------------------------------------- #
-# 3. Merge built-in rules into settings.json permissions                      #
+# 3. Install Notification hook (macOS only)                                   #
+# --------------------------------------------------------------------------- #
+
+if [[ "$(uname)" == "Darwin" ]]; then
+  section "Installing Notification hook"
+
+  notify_source_dir="$SCRIPT_DIR/hooks/Notification"
+
+  if [[ -f "$notify_source_dir/notify-attention.sh" ]]; then
+    cp "$notify_source_dir/notify-attention.sh" "$HOOKS_DIR/notify-attention.sh"
+    cp "$notify_source_dir/focus-claude-session.sh" "$HOOKS_DIR/focus-claude-session.sh"
+    chmod +x "$HOOKS_DIR/notify-attention.sh" "$HOOKS_DIR/focus-claude-session.sh"
+    ok "Entry point → $HOOKS_DIR/notify-attention.sh"
+
+    if ! command -v terminal-notifier >/dev/null 2>&1; then
+      warn "terminal-notifier not installed (brew install terminal-notifier); hook will no-op until it is"
+    fi
+
+    # Ensure hook is registered in settings.json
+    python3 - "$CLAUDE_SETTINGS" <<'PYEOF'
+import json
+import sys
+
+settings_path = sys.argv[1]
+hook_command = "~/.claude/hooks/notify-attention.sh"
+
+try:
+    with open(settings_path) as f:
+        settings = json.load(f)
+except (FileNotFoundError, json.JSONDecodeError):
+    settings = {}
+
+hooks = settings.setdefault("hooks", {})
+notification = hooks.setdefault("Notification", [])
+
+already = any(
+    hook_command in h.get("command", "")
+    for entry in notification
+    for h in entry.get("hooks", [])
+)
+
+if not already:
+    notification.append({
+        "hooks": [{"type": "command", "command": hook_command}]
+    })
+    with open(settings_path, "w") as f:
+        json.dump(settings, f, indent=2)
+        f.write("\n")
+    print("  \033[32m✓\033[0m Hook registered in settings.json")
+else:
+    print("  \033[2m· Hook already registered in settings.json\033[0m")
+PYEOF
+
+  else
+    warn "$notify_source_dir/notify-attention.sh not found, skipping"
+  fi
+fi
+
+# --------------------------------------------------------------------------- #
+# 4. Merge built-in rules into settings.json permissions                      #
 # --------------------------------------------------------------------------- #
 
 section "Merging permissions"
@@ -377,7 +436,37 @@ else
 fi
 
 # --------------------------------------------------------------------------- #
-# 4. Register MCP servers                                                     #
+# 5. Disable Claude session-URL commit/PR trailer                             #
+# --------------------------------------------------------------------------- #
+
+section "Disabling Claude session-URL attribution"
+
+python3 - "$CLAUDE_SETTINGS" <<'PYEOF'
+import json
+import sys
+
+settings_path = sys.argv[1]
+
+try:
+    with open(settings_path) as f:
+        settings = json.load(f)
+except (FileNotFoundError, json.JSONDecodeError):
+    settings = {}
+
+attribution = settings.setdefault("attribution", {})
+
+if attribution.get("sessionUrl") is False:
+    print("  \033[2m· Session-URL trailer already disabled\033[0m")
+else:
+    attribution["sessionUrl"] = False
+    with open(settings_path, "w") as f:
+        json.dump(settings, f, indent=2)
+        f.write("\n")
+    print("  \033[32m✓\033[0m Session-URL trailer disabled (attribution.sessionUrl=false)")
+PYEOF
+
+# --------------------------------------------------------------------------- #
+# 6. Register MCP servers                                                     #
 # --------------------------------------------------------------------------- #
 
 section "Registering MCP servers"
@@ -408,7 +497,7 @@ _register_mcp() {
 _register_mcp "playwright" "@playwright/mcp" -- npx @playwright/mcp@latest
 
 # --------------------------------------------------------------------------- #
-# 5. Upsert <agent-skills-guidance> block in CLAUDE.md                        #
+# 7. Upsert <agent-skills-guidance> block in CLAUDE.md                        #
 # --------------------------------------------------------------------------- #
 
 section "Updating CLAUDE.md"
@@ -471,7 +560,7 @@ else
 fi
 
 # --------------------------------------------------------------------------- #
-# 6. Install CLI scripts                                                      #
+# 8. Install CLI scripts                                                      #
 # --------------------------------------------------------------------------- #
 
 section "Installing CLI scripts"

--- a/setup.sh
+++ b/setup.sh
@@ -436,11 +436,16 @@ else
 fi
 
 # --------------------------------------------------------------------------- #
-# 5. Disable Claude session-URL commit/PR trailer                             #
+# 5. Disable Claude auto-attribution (commit/PR trailers + session URL)        #
 # --------------------------------------------------------------------------- #
 
-section "Disabling Claude session-URL attribution"
+section "Disabling Claude auto-attribution"
 
+# We append our own trailers manually (see ~/.claude/CLAUDE.md), so turn off
+# Claude Code's auto-attribution entirely to avoid duplicates:
+#   attribution.sessionUrl = false  → drop the session-URL line
+#   attribution.commit      = ""     → no auto commit trailer
+#   attribution.pr          = ""     → no auto PR trailer
 python3 - "$CLAUDE_SETTINGS" <<'PYEOF'
 import json
 import sys
@@ -455,14 +460,18 @@ except (FileNotFoundError, json.JSONDecodeError):
 
 attribution = settings.setdefault("attribution", {})
 
-if attribution.get("sessionUrl") is False:
-    print("  \033[2m· Session-URL trailer already disabled\033[0m")
+desired = {"sessionUrl": False, "commit": "", "pr": ""}
+if all(attribution.get(k) == v for k, v in desired.items()):
+    print("  \033[2m· Auto-attribution already disabled\033[0m")
 else:
-    attribution["sessionUrl"] = False
+    attribution.update(desired)
     with open(settings_path, "w") as f:
         json.dump(settings, f, indent=2)
         f.write("\n")
-    print("  \033[32m✓\033[0m Session-URL trailer disabled (attribution.sessionUrl=false)")
+    print(
+        "  \033[32m✓\033[0m Auto-attribution disabled "
+        "(sessionUrl=false, commit=\"\", pr=\"\")"
+    )
 PYEOF
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Two related personal/machine-local Claude Code setup improvements, rescued from an uncommitted working tree (they had been sitting on the now-merged `add-failsafe-monitor-guidance` branch).

**1. Hook-engine user-local rules overlay**
- `load_user_local_rules()` in `engine.py` merges additive PreToolUse rules from `~/.agent-skills/local-rules.json`, wired into `interpreter.py`.
- Lets a user enforce private (e.g. org-specific) rules without committing them to this shared repo. Full rule objects, so normal deny > ask > allow priority applies.
- Fails open when the file is absent or malformed — a broken personal overlay never breaks every tool call.
- Documented in `hooks/PreToolUse/CLAUDE.md`; covered by `tests/test_user_local_rules.py`.

**2. macOS Notification hook + setup tweaks**
- Installs `hooks/Notification/{notify-attention,focus-claude-session}.sh` on macOS and registers the Notification hook in `settings.json`. Clickable banner when Claude needs attention; clicking focuses the hosting window (Ghostty native OSC 777 / VS Code / Superset). No-ops without `terminal-notifier`.
- **Disables Claude Code's auto-attribution entirely** in `settings.json`: `attribution.sessionUrl=false`, `attribution.commit=""`, `attribution.pr=""`. We append our own commit/PR trailers manually (per `~/.claude/CLAUDE.md`), so the auto trailers (`Co-Authored-By: Claude`, `🤖 Generated with Claude Code`) would only produce duplicates. The step is idempotent.

## Verification

### Hooks (PreToolUse)
- [x] `cd hooks/PreToolUse && uvx pytest tests/` — 486 passing (includes new overlay tests)
- [x] `make check` (format + lint) clean

### Setup / CI / Infra
- [x] `bash -n setup.sh` syntax-clean; attribution heredoc tested standalone (updates once, idempotent after, preserves other keys)
- [ ] Run `setup.sh` on a clean state to confirm the Notification hook install + attribution sections complete without errors