### PR TITLE
Add guidance: don't hard-wrap text posted or handed off to external services

### DIFF
--- a/templates/user-claude.md
+++ b/templates/user-claude.md
@@ -291,6 +291,25 @@ After the immediate fix is done, proactively offer a systemic improvement: a rul
 template update, a test to add. Don't wait to be asked. Frame it as "here's how we prevent this"
 not "here's why I failed."
 
+## Don't Hard-Wrap Text You Post or Hand Off
+
+Text you generate for the user to paste — or that you post on their behalf — into a
+service that soft-wraps (GitHub PRs/issues/comments, Linear, Notion, Slack, email,
+chat) must NOT contain manual mid-paragraph line breaks. Write each paragraph as one
+continuous line and let the destination wrap it. Hard-wrapping at a fixed column
+fights the renderer, produces ragged, awkwardly broken text, and makes the content
+harder to edit and re-flow. This is a readability and manageability issue, not an
+aesthetic preference — and it applies equally when you post the text yourself.
+
+Keep line breaks only where the format needs them: between paragraphs (blank line),
+list items, table rows, headings, and inside fenced code blocks.
+
+**The one exception is a source file in a repo that defines a line-length convention**
+(e.g. a codebase whose lint or pre-commit caps comment/code width, or a doc that is
+already prose-wrapped). There, match the surrounding convention — consistency with the
+file wins, and wrapping proactively is correct. Everywhere else, default to no manual
+wrapping.
+
 ## CLAUDE.md vs .claude/rules/
 
 Use a clear separation between orientation and directives:


### PR DESCRIPTION
Adds a `user-claude.md` guideline: text generated for the user to paste — or posted on their behalf — into soft-wrapping services (GitHub PRs/issues/comments, Linear, Notion, Slack, email, chat) must not contain manual mid-paragraph line breaks. Write flowing paragraphs and let the destination wrap. Hard-wrapping fights the renderer, reads ragged, and makes the text harder to edit and re-flow. It's a readability/manageability issue, not an aesthetic preference, and it applies equally when the agent posts the text itself.

The one carved-out exception is a source file in a repo with a defined line-length convention (a lint/pre-commit width cap, or a doc that's already prose-wrapped), where matching the surrounding convention wins — so wrapping proactively there is correct.

Placed in the universal `user-claude.md` rather than a per-user template, since it's a general correctness rule, not a personal preference.
