### PR TITLE
Add batch-edit write-discipline rule

### DIFF
--- a/templates/user-claude.md
+++ b/templates/user-claude.md
@@ -192,6 +192,16 @@ context-dependent fixes), coordinate as a hub and delegate to parallel sub-agent
 6. **Keep your own context clean.** The point of delegation is that agent results stay out of
    your main context. Summarize outcomes; don't paste raw output back into the conversation.
 
+## Batch Edit Scripts: Write Per-Edit or At-End — Never Assert Mid-Batch
+
+A script that applies multiple text replacements and asserts between them
+loses every already-applied edit when a later assertion fails before the
+write. Either write the file after each successful replacement, or collect
+all replacements and assert them ALL before writing once. After any batch
+script fails partway, re-verify which edits actually landed — do not trust
+the ones that "ran before the error," and do not assume the failed ones
+were the only casualties.
+
 ## Long-Running Background Waits — Never Die Silently
 
 When waiting on anything long-running in the background — CI deploys, load tests, builds,


### PR DESCRIPTION
Adds a rule to `templates/user-claude.md`: multi-replacement edit scripts must write per-edit or assert-all-then-write-once — a mid-batch assertion failure before the write silently discards every "applied" edit. After a partial failure, re-verify which edits actually landed.

Learned the hard way in the onboarding-course session: a failed assertion discarded three already-applied review fixes, caught only when a later reviewer quoted supposedly-fixed text.